### PR TITLE
Fixed typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sudo apt-get install git
 git clone https://github.com/sajmons/CollimationCircles.git
 ```
 ```
-cd ColliminationCircles/ColliminationCircles
+cd CollimationCircles/CollimationCircles
 ```
 ```
 dotnet run


### PR DESCRIPTION
Hi!

I tried to install the app from the guidance from the `Readme` file, and met the error during the `cd` command:
` cd ColliminationCircles/ColliminationCircles `

![image](https://github.com/sajmons/CollimationCircles/assets/119358312/dc356152-c2e8-4b33-b2b4-003b4721028d)

I found this as a typo, and fixed to correct `cd` command:
![image](https://github.com/sajmons/CollimationCircles/assets/119358312/e2dc7009-4f73-4847-94c3-da0b1ef4ea49)

Hope it helps!
Cheers!