### PR TITLE
Improve macOS arm64 LibVLC compatibility with degraded mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,14 @@
 ################################################################################
 
 /.vs
+/artifacts
 /FocusMaskTestImages
+/appstate.json
 /CollimationCircles/appstate.json
 /LibVLCSharp.Avalonia.Unofficial/obj
 /LibVLCSharp.Avalonia.Unofficial/bin/Debug/net6.0
 /LibVLCSharp.Avalonia.Unofficial/bin/Debug/net7.0
+/CollimationCirclesFeatures/bin
 /CollimationCirclesFeatures/obj
 /CollimationCirclesFeatures/bin/Debug/net8.0
 /CollimationCirclesFeatures/bin/Release/net8.0

--- a/CollimationCircles/App.axaml.cs
+++ b/CollimationCircles/App.axaml.cs
@@ -1,13 +1,18 @@
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
 using CollimationCircles.Services;
 using CollimationCircles.ViewModels;
 using CollimationCircles.Views;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using HanumanInstitute.MvvmDialogs;
 using HanumanInstitute.MvvmDialogs.Avalonia;
+using HanumanInstitute.MvvmDialogs.FrameworkDialogs;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
 
 namespace CollimationCircles;
 public partial class App : Application
@@ -26,6 +31,7 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             SettingsViewModel vm = Ioc.Default.GetRequiredService<SettingsViewModel>();
+            ILibVLCService libVLCService = Ioc.Default.GetRequiredService<ILibVLCService>();
 
             vm.LoadState();
 
@@ -33,6 +39,24 @@ public partial class App : Application
             {
                 Topmost = vm.AlwaysOnTop
             };
+
+            if (!libVLCService.IsAvailable)
+            {
+                if (desktop.MainWindow.IsVisible)
+                {
+                    _ = ShowLibVlcCompatibilityMessageAsync(desktop.MainWindow);
+                }
+                else
+                {
+                    async void OnOpened(object? sender, System.EventArgs args)
+                    {
+                        desktop.MainWindow.Opened -= OnOpened;
+                        await ShowLibVlcCompatibilityMessageAsync(desktop.MainWindow);
+                    }
+
+                    desktop.MainWindow.Opened += OnOpened;
+                }
+            }
         }
 
         base.OnFrameworkInitializationCompleted();
@@ -66,5 +90,63 @@ public partial class App : Application
             .AddSingleton<ILibVLCService, LibVLCService>()
             .AddTransient<ImageViewModel>()
             .BuildServiceProvider());
+    }
+
+    private static async Task ShowLibVlcCompatibilityMessageAsync(Window owner)
+    {
+        IResourceService resourceService = Ioc.Default.GetRequiredService<IResourceService>();
+
+        string message =
+            resourceService.TryGetString("LibVlcCompatibilityBody1") + "\n\n" +
+            resourceService.TryGetString("LibVlcCompatibilityBody2") + "\n" +
+            resourceService.TryGetString("LibVlcCompatibilityBody3") + "\n" +
+            resourceService.TryGetString("LibVlcCompatibilityBody4") + "\n" +
+            resourceService.TryGetString("LibVlcCompatibilityBody5") + "\n" +
+            resourceService.TryGetString("LibVlcCompatibilityBody6");
+
+        var dialog = new Window
+        {
+            Title = resourceService.TryGetString("LibVlcCompatibilityTitle"),
+            Width = 620,
+            MinWidth = 520,
+            Height = 360,
+            MinHeight = 300,
+            CanResize = true,
+            ShowInTaskbar = false,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Topmost = true,
+            ExtendClientAreaToDecorationsHint = false,
+            TransparencyLevelHint = [WindowTransparencyLevel.None],
+            Background = new SolidColorBrush(Color.Parse("#202124")),
+            Opacity = 1.0
+        };
+
+        var okButton = new Button
+        {
+            Content = "OK",
+            MinWidth = 120,
+            HorizontalAlignment = HorizontalAlignment.Center
+        };
+
+        okButton.Click += (_, _) => dialog.Close();
+
+        dialog.Content = new StackPanel
+        {
+            Margin = new Thickness(20),
+            Spacing = 12,
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = message,
+                    Foreground = new SolidColorBrush(Color.Parse("#F1F3F4")),
+                    TextWrapping = TextWrapping.Wrap,
+                    VerticalAlignment = VerticalAlignment.Stretch
+                },
+                okButton
+            }
+        };
+
+        await dialog.ShowDialog(owner);
     }
 }

--- a/CollimationCircles/CollimationCircles.csproj
+++ b/CollimationCircles/CollimationCircles.csproj
@@ -11,8 +11,8 @@
     <PackageProjectUrl>https://github.com/sajmons/CollimationCircles</PackageProjectUrl>
     <RepositoryUrl>https://github.com/sajmons/CollimationCircles</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>4.0.0</Version>
-    <InformationalVersion>4.0.0</InformationalVersion>
+    <Version>4.0.1-macos</Version>
+    <InformationalVersion>4.0.1-macos</InformationalVersion>
     <Authors>Simon Šander</Authors>
     <Product>Collimation Circles</Product>
     <Copyright>Copyright © 2023</Copyright>

--- a/CollimationCircles/Program.cs
+++ b/CollimationCircles/Program.cs
@@ -2,6 +2,9 @@
 using CollimationCircles.Services;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace CollimationCircles
@@ -9,9 +12,13 @@ namespace CollimationCircles
     internal class Program
     {
         private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+        private const string MacArm64BootstrapFlag = "COLLIMATIONCIRCLES_VLC_ENV_BOOTSTRAPPED";
 
         private static bool IsLinuxArm64 =>
             OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
+
+        private static bool IsMacArm64 =>
+            OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
 
         // Initialization code. Don't use any Avalonia, third-party APIs or any
         // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
@@ -27,6 +34,7 @@ namespace CollimationCircles
 
             try
             {
+                BootstrapMacArm64VlcEnvironment(args);
                 ConfigureLinuxEnvironment();
 
                 AppService.LogSystemInformation();
@@ -43,6 +51,182 @@ namespace CollimationCircles
             {
                 NLog.LogManager.Shutdown();
             }
+        }
+
+        private static void BootstrapMacArm64VlcEnvironment(string[] args)
+        {
+            if (!IsMacArm64)
+            {
+                return;
+            }
+
+            if (!TryGetMacVlcPaths(out string libPath, out string pluginPath, out string dataPath))
+            {
+                logger.Warn("No macOS VLC installation found for arm64 bootstrap.");
+                return;
+            }
+
+            bool alreadyBootstrapped = string.Equals(
+                Environment.GetEnvironmentVariable(MacArm64BootstrapFlag),
+                "1",
+                StringComparison.Ordinal);
+
+            if (alreadyBootstrapped)
+            {
+                logger.Info("macOS arm64 VLC bootstrap already applied for this process.");
+                return;
+            }
+
+            if (NeedsMacVlcBootstrap(libPath, pluginPath, dataPath))
+            {
+                RelaunchCurrentProcessWithVlcEnvironment(libPath, pluginPath, dataPath, args);
+            }
+        }
+
+        private static bool NeedsMacVlcBootstrap(string libPath, string pluginPath, string dataPath)
+        {
+            string? pluginEnv = Environment.GetEnvironmentVariable("VLC_PLUGIN_PATH");
+            string? dataEnv = Environment.GetEnvironmentVariable("VLC_DATA_PATH");
+
+            bool pluginMatches = string.Equals(pluginEnv, pluginPath, StringComparison.Ordinal);
+            bool dataMatches = string.Equals(dataEnv, dataPath, StringComparison.Ordinal);
+            bool dyldHasPath = PathListContains(Environment.GetEnvironmentVariable("DYLD_LIBRARY_PATH"), libPath) ||
+                               PathListContains(Environment.GetEnvironmentVariable("DYLD_FALLBACK_LIBRARY_PATH"), libPath);
+
+            return !pluginMatches || !dataMatches || !dyldHasPath;
+        }
+
+        private static void RelaunchCurrentProcessWithVlcEnvironment(string libPath, string pluginPath, string dataPath, string[] args)
+        {
+            string[] commandLineArgs = Environment.GetCommandLineArgs();
+            if (commandLineArgs.Length == 0)
+            {
+                logger.Warn("Unable to relaunch process for macOS arm64 VLC bootstrap: no command line args.");
+                return;
+            }
+
+            string executable = commandLineArgs[0];
+            var relaunchArguments = new List<string>();
+
+            if (executable.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            {
+                string? dotnetHost = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+                if (string.IsNullOrWhiteSpace(dotnetHost))
+                {
+                    dotnetHost = Process.GetCurrentProcess().MainModule?.FileName;
+                }
+
+                executable = string.IsNullOrWhiteSpace(dotnetHost) ? "dotnet" : dotnetHost;
+                relaunchArguments.Add(commandLineArgs[0]);
+                relaunchArguments.AddRange(commandLineArgs.Skip(1));
+            }
+            else
+            {
+                relaunchArguments.AddRange(commandLineArgs.Skip(1));
+            }
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = executable,
+                UseShellExecute = false
+            };
+
+            foreach (string arg in relaunchArguments)
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
+
+            startInfo.Environment[MacArm64BootstrapFlag] = "1";
+            startInfo.Environment["VLC_PLUGIN_PATH"] = pluginPath;
+            startInfo.Environment["VLC_DATA_PATH"] = dataPath;
+            startInfo.Environment["DYLD_LIBRARY_PATH"] = MergePathList(startInfo.Environment.TryGetValue("DYLD_LIBRARY_PATH", out string? dyldLibraryPath) ? dyldLibraryPath : null, libPath);
+            startInfo.Environment["DYLD_FALLBACK_LIBRARY_PATH"] = MergePathList(startInfo.Environment.TryGetValue("DYLD_FALLBACK_LIBRARY_PATH", out string? dyldFallbackPath) ? dyldFallbackPath : null, libPath);
+
+            logger.Info($"Relaunching process with macOS arm64 VLC env. lib='{libPath}' plugins='{pluginPath}'");
+
+            Process.Start(startInfo);
+            Environment.Exit(0);
+        }
+
+        private static bool TryGetMacVlcPaths(out string libPath, out string pluginPath, out string dataPath)
+        {
+            foreach (string appPath in GetMacVlcAppPaths())
+            {
+                libPath = Path.Combine(appPath, "Contents", "MacOS", "lib");
+                pluginPath = Path.Combine(appPath, "Contents", "MacOS", "plugins");
+                dataPath = Path.Combine(appPath, "Contents", "MacOS", "share");
+
+                if (Directory.Exists(libPath) && Directory.Exists(pluginPath) && Directory.Exists(dataPath))
+                {
+                    return true;
+                }
+            }
+
+            libPath = string.Empty;
+            pluginPath = string.Empty;
+            dataPath = string.Empty;
+            return false;
+        }
+
+        private static IEnumerable<string> GetMacVlcAppPaths()
+        {
+            yield return "/Applications/VLC.app";
+
+            const string caskRoot = "/opt/homebrew/Caskroom/vlc";
+            if (!Directory.Exists(caskRoot))
+            {
+                yield break;
+            }
+
+            string[] versionDirs;
+            try
+            {
+                versionDirs = Directory.GetDirectories(caskRoot)
+                    .OrderByDescending(x => x, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+            }
+            catch
+            {
+                yield break;
+            }
+
+            foreach (string versionDir in versionDirs)
+            {
+                yield return Path.Combine(versionDir, "VLC.app");
+            }
+        }
+
+        private static bool PathListContains(string? pathList, string path)
+        {
+            if (string.IsNullOrWhiteSpace(pathList))
+            {
+                return false;
+            }
+
+            char separator = Path.PathSeparator;
+            return pathList
+                .Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Contains(path, StringComparer.Ordinal);
+        }
+
+        private static string MergePathList(string? current, string pathToAdd)
+        {
+            if (string.IsNullOrWhiteSpace(current))
+            {
+                return pathToAdd;
+            }
+
+            char separator = Path.PathSeparator;
+            List<string> parts = current
+                .Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+
+            if (!parts.Contains(pathToAdd, StringComparer.Ordinal))
+            {
+                parts.Insert(0, pathToAdd);
+            }
+
+            return string.Join(separator, parts);
         }
 
         /// <summary>

--- a/CollimationCircles/Resources/Lang/de-DE.axaml
+++ b/CollimationCircles/Resources/Lang/de-DE.axaml
@@ -175,5 +175,12 @@
   <system:String x:Key="Text.TooManyCirclesDetected">Zu viele Kreise erkannt</system:String>
   <system:String x:Key="Text.DetectionThresholdHelp">Versuchen Sie, den Schwellenwert zu ändern.</system:String>
   <system:String x:Key="Text.DetectionThresholdHelp2">Das Bild sollte einen zentrierten, defokussierten Stern enthalten</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityTitle">LibVLC-Kompatibilitätsfehler</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody1">Der Live-Videostream ist nicht verfügbar, weil native LibVLC-Bibliotheken auf dieser Plattform fehlen oder inkompatibel sind.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody2">Die Anwendung wird im eingeschränkten Modus fortgesetzt.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody3">Nicht verfügbare Funktionen: Live-Kamera-Videovorschau.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody4">Nicht verfügbare Funktionen: Stream Wiedergabe/Pause und Snapshot aus dem Live-Stream für die Analyse.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody5">Nicht-video Funktionen bleiben nutzbar (Overlay-Einrichtung, Profile und Bildanalyse aus Datei).</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody6">Installieren Sie arm64-kompatibles VLC/libVLC und starten Sie die Anwendung neu.</system:String>
   <system:String x:Key="Text.EnterOpenApiKey">Enter OpenApi Key here</system:String>
 </ResourceDictionary>

--- a/CollimationCircles/Resources/Lang/en-US.axaml
+++ b/CollimationCircles/Resources/Lang/en-US.axaml
@@ -175,5 +175,12 @@
   <system:String x:Key="Text.TooManyCirclesDetected">Too many circles detected</system:String>  
   <system:String x:Key="Text.DetectionThresholdHelp">Try changing threshold.</system:String>
   <system:String x:Key="Text.DetectionThresholdHelp2">Image should contain centered defocused star</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityTitle">LibVLC Compatibility Error</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody1">Live video stream is not available because LibVLC native libraries are missing or incompatible on this platform.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody2">The application will continue in degraded mode.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody3">Unavailable features: live camera video preview.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody4">Unavailable features: stream play/pause and snapshot from live stream for analysis.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody5">You can still use non-video features (overlay setup, profiles, and image analysis from file).</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody6">Install arm64-compatible VLC/libVLC and restart the app.</system:String>
   <system:String x:Key="Text.EnterOpenApiKey">Enter OpenApi Key here</system:String>  
 </ResourceDictionary>

--- a/CollimationCircles/Resources/Lang/fr-FR.axaml
+++ b/CollimationCircles/Resources/Lang/fr-FR.axaml
@@ -175,5 +175,12 @@
   <system:String x:Key="Text.TooManyCirclesDetected">Trop de cercles détectés</system:String>
   <system:String x:Key="Text.DetectionThresholdHelp">Essayez de changer le seuil.</system:String>
   <system:String x:Key="Text.DetectionThresholdHelp2">L'image doit contenir une étoile centrée et défocalisée</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityTitle">Erreur de compatibilité LibVLC</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody1">Le flux vidéo en direct n'est pas disponible car les bibliothèques natives LibVLC sont manquantes ou incompatibles sur cette plateforme.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody2">L'application continuera en mode dégradé.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody3">Fonctionnalités indisponibles : aperçu vidéo de la caméra en direct.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody4">Fonctionnalités indisponibles : lecture/pause du flux et capture instantanée depuis le flux en direct pour l'analyse.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody5">Vous pouvez toujours utiliser les fonctionnalités sans vidéo (configuration des overlays, profils et analyse d'image depuis un fichier).</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody6">Installez VLC/libVLC compatible arm64 puis redémarrez l'application.</system:String>
   <system:String x:Key="Text.EnterOpenApiKey">Enter OpenApi Key here</system:String>
 </ResourceDictionary>

--- a/CollimationCircles/Resources/Lang/sl-SI.axaml
+++ b/CollimationCircles/Resources/Lang/sl-SI.axaml
@@ -175,5 +175,12 @@
   <system:String x:Key="Text.TooManyCirclesDetected">Zaznanih je preveč krogov</system:String>
   <system:String x:Key="Text.DetectionThresholdHelp">Poskusite spremeniti prag.</system:String>
   <system:String x:Key="Text.DetectionThresholdHelp2">Slika mora vsebovati centrirano defokusirano zvezdo</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityTitle">Napaka združljivosti LibVLC</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody1">Video prenos v živo ni na voljo, ker manjkajo ali niso združljive izvorne knjižnice LibVLC za to platformo.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody2">Aplikacija se bo nadaljevala v omejenem načinu.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody3">Nedosegljive funkcije: predogled videa kamere v živo.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody4">Nedosegljive funkcije: predvajanje/pavza prenosa in zajem slike iz prenosa v živo za analizo.</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody5">Funkcije brez videa še vedno delujejo (nastavitve prekrivanj, profili in analiza slike iz datoteke).</system:String>
+  <system:String x:Key="Text.LibVlcCompatibilityBody6">Namestite arm64 združljiv VLC/libVLC in znova zaženite aplikacijo.</system:String>
   <system:String x:Key="Text.EnterOpenApiKey">Enter OpenApi Key here</system:String>
 </ResourceDictionary>

--- a/CollimationCircles/Services/DShowCameraDetect.cs
+++ b/CollimationCircles/Services/DShowCameraDetect.cs
@@ -147,7 +147,7 @@ namespace CollimationCircles.Services
                 {
                     ICameraControl? cameraControl = camera.Controls.FirstOrDefault(c => c.Name == controlName);
 
-                    if (cameraControl is not null)
+                    if (cameraControl is not null && vlc.MediaPlayer is not null)
                     {
                         float val = (float)ConvertRange(cameraControl.Min, cameraControl.Max, value);
 

--- a/CollimationCircles/Services/ILibVLCService.cs
+++ b/CollimationCircles/Services/ILibVLCService.cs
@@ -7,7 +7,8 @@ namespace CollimationCircles.Services
     public interface ILibVLCService
     {
         public string FullAddress { get; set; }
-        public MediaPlayer MediaPlayer { get; }
+        public bool IsAvailable { get; }
+        public MediaPlayer? MediaPlayer { get; }
         public Task Play(Camera camera, bool displayAdvancedDShowDialog);
         public string DefaultAddress(Camera camera);
         public void TakeSnapshot();

--- a/CollimationCircles/Services/LibVLCService.cs
+++ b/CollimationCircles/Services/LibVLCService.cs
@@ -7,6 +7,9 @@ using LibVLCSharp.Shared;
 using Octokit;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace CollimationCircles.Services
@@ -14,7 +17,15 @@ namespace CollimationCircles.Services
     internal class LibVLCService : ILibVLCService
     {
         private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-        private readonly LibVLC libVLC;
+        private static readonly string[] MacArm64LibVlcSearchPaths =
+        [
+            "/opt/homebrew/opt/vlc/lib",
+            "/opt/homebrew/lib",
+            "/usr/local/lib"
+        ];
+        private static readonly List<nint> NativeLibraryHandles = [];
+
+        private readonly LibVLC? libVLC;
 
         private string protocol = string.Empty;
         private string address = string.Empty;
@@ -24,8 +35,9 @@ namespace CollimationCircles.Services
 
         public const string SnapshotImageFile = "snapshot.jpg";
 
+        public bool IsAvailable { get; }
         public string FullAddress { get; set; } = string.Empty;
-        public MediaPlayer MediaPlayer { get; }
+        public MediaPlayer? MediaPlayer { get; }
 
         public LibVLCService()
         {
@@ -35,43 +47,281 @@ namespace CollimationCircles.Services
                 "--verbose=3"
             ];
 
-            libVLC = new(libVLCOptions);
-
-            libVLC.Log += (sender, e) =>
+            if (TryInitializeMacArm64LibVlc(libVLCOptions, out LibVLC? arm64LibVlc, out MediaPlayer? arm64MediaPlayer))
             {
-                switch (e.Level)
+                libVLC = arm64LibVlc;
+                MediaPlayer = arm64MediaPlayer;
+
+                if (MediaPlayer is not null)
                 {
-                    case LogLevel.Error:
-                        logger.Error($"LibVLC: {e.Module} {e.Message}");
-                        break;
-                    case LogLevel.Debug:
-                        logger.Debug($"LibVLC: {e.Module} {e.Message}");
-                        break;
-                    case LogLevel.Warning:
-                        logger.Warn($"LibVLC: {e.Module} {e.Message}");
-                        break;
-                    case LogLevel.Notice:
-                        logger.Info($"LibVLC: {e.Module} {e.Message}");
-                        break;
+                    MediaPlayer.Opening += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Opening));
+                    MediaPlayer.Playing += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Playing));
+                    MediaPlayer.Paused += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Paused));
+                    MediaPlayer.Stopped += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Stopped));
                 }
-            };
 
-            MediaPlayer = new(libVLC)
+                IsAvailable = true;
+                logger.Info("LibVLC initialized from macOS arm64 fallback path.");
+                return;
+            }
+
+            try
             {
-                FileCaching = 0,
-                NetworkCaching = 0,
-                EnableHardwareDecoding = true
-            };
+                libVLC = new(libVLCOptions);
 
-            MediaPlayer.Opening += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Opening));
-            MediaPlayer.Playing += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Playing));
-            MediaPlayer.Paused += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Paused));
-            MediaPlayer.Stopped += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Stopped));
+                libVLC.Log += (sender, e) =>
+                {
+                    switch (e.Level)
+                    {
+                        case LogLevel.Error:
+                            logger.Error($"LibVLC: {e.Module} {e.Message}");
+                            break;
+                        case LogLevel.Debug:
+                            logger.Debug($"LibVLC: {e.Module} {e.Message}");
+                            break;
+                        case LogLevel.Warning:
+                            logger.Warn($"LibVLC: {e.Module} {e.Message}");
+                            break;
+                        case LogLevel.Notice:
+                            logger.Info($"LibVLC: {e.Module} {e.Message}");
+                            break;
+                    }
+                };
+
+                MediaPlayer = new(libVLC)
+                {
+                    FileCaching = 0,
+                    NetworkCaching = 0,
+                    EnableHardwareDecoding = true
+                };
+
+                MediaPlayer.Opening += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Opening));
+                MediaPlayer.Playing += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Playing));
+                MediaPlayer.Paused += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Paused));
+                MediaPlayer.Stopped += (sender, e) => WeakReferenceMessenger.Default.Send(new CameraStateMessage(CameraState.Stopped));
+
+                IsAvailable = true;
+            }
+            catch (Exception ex)
+            {
+                logger.Warn(ex, "Default LibVLC loading failed.");
+                IsAvailable = false;
+                logger.Error(ex, "LibVLC disabled.");
+            }
+        }
+
+        private static bool TryInitializeMacArm64LibVlc(string[] libVLCOptions, out LibVLC? fallbackLibVlc, out MediaPlayer? fallbackMediaPlayer)
+        {
+            fallbackLibVlc = null;
+            fallbackMediaPlayer = null;
+
+            if (!OperatingSystem.IsMacOS() || RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            {
+                return false;
+            }
+
+            foreach (string searchPath in GetMacArm64LibVlcCandidatePaths())
+            {
+                string dylibPath = Path.Combine(searchPath, "libvlc.dylib");
+
+                if (!File.Exists(dylibPath))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (!TryPreloadMacArm64Libraries(searchPath, out string preloadError))
+                    {
+                        logger.Warn($"LibVLC preload failed for '{searchPath}': {preloadError}");
+                        continue;
+                    }
+
+                    string? pluginPath = TryGetPluginPathFromLibPath(searchPath);
+                    string? dataPath = TryGetDataPathFromLibPath(searchPath);
+
+                    if (!string.IsNullOrWhiteSpace(pluginPath))
+                    {
+                        Environment.SetEnvironmentVariable("VLC_PLUGIN_PATH", pluginPath);
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(dataPath))
+                    {
+                        Environment.SetEnvironmentVariable("VLC_DATA_PATH", dataPath);
+                    }
+
+                    MergePathEnvironment("DYLD_LIBRARY_PATH", searchPath);
+                    MergePathEnvironment("DYLD_FALLBACK_LIBRARY_PATH", searchPath);
+
+                    Core.Initialize(searchPath);
+
+                    fallbackLibVlc = new LibVLC(libVLCOptions);
+                    fallbackMediaPlayer = new MediaPlayer(fallbackLibVlc)
+                    {
+                        FileCaching = 0,
+                        NetworkCaching = 0,
+                        EnableHardwareDecoding = true
+                    };
+
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    logger.Warn($"LibVLC fallback init failed for '{searchPath}': {ex.Message}");
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryPreloadMacArm64Libraries(string libPath, out string error)
+        {
+            error = string.Empty;
+
+            string corePath = Path.Combine(libPath, "libvlccore.dylib");
+            string vlcPath = Path.Combine(libPath, "libvlc.dylib");
+
+            if (!File.Exists(corePath) || !File.Exists(vlcPath))
+            {
+                error = "Required files libvlc.dylib/libvlccore.dylib are missing.";
+                return false;
+            }
+
+            if (!NativeLibrary.TryLoad(corePath, out nint coreHandle))
+            {
+                error = $"Could not load '{corePath}'.";
+                return false;
+            }
+
+            if (!NativeLibrary.TryLoad(vlcPath, out nint vlcHandle))
+            {
+                error = $"Could not load '{vlcPath}'.";
+                return false;
+            }
+
+            NativeLibraryHandles.Add(coreHandle);
+            NativeLibraryHandles.Add(vlcHandle);
+
+            return true;
+        }
+
+        private static string? TryGetPluginPathFromLibPath(string libPath)
+        {
+            try
+            {
+                var libDirInfo = new DirectoryInfo(libPath);
+                if (!libDirInfo.Exists)
+                {
+                    return null;
+                }
+
+                string? macOsDir = libDirInfo.Parent?.FullName;
+                if (string.IsNullOrWhiteSpace(macOsDir))
+                {
+                    return null;
+                }
+
+                string pluginsPath = Path.Combine(macOsDir, "plugins");
+                return Directory.Exists(pluginsPath) ? pluginsPath : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string? TryGetDataPathFromLibPath(string libPath)
+        {
+            try
+            {
+                var libDirInfo = new DirectoryInfo(libPath);
+                if (!libDirInfo.Exists)
+                {
+                    return null;
+                }
+
+                string? macOsDir = libDirInfo.Parent?.FullName;
+                if (string.IsNullOrWhiteSpace(macOsDir))
+                {
+                    return null;
+                }
+
+                string sharePath = Path.Combine(macOsDir, "share");
+                return Directory.Exists(sharePath) ? sharePath : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static void MergePathEnvironment(string variable, string pathToAdd)
+        {
+            if (string.IsNullOrWhiteSpace(pathToAdd))
+            {
+                return;
+            }
+
+            var existing = Environment.GetEnvironmentVariable(variable);
+            if (string.IsNullOrWhiteSpace(existing))
+            {
+                Environment.SetEnvironmentVariable(variable, pathToAdd);
+                return;
+            }
+
+            var separator = Path.PathSeparator;
+            var parts = existing
+                .Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+
+            if (!parts.Contains(pathToAdd, StringComparer.Ordinal))
+            {
+                parts.Insert(0, pathToAdd);
+                Environment.SetEnvironmentVariable(variable, string.Join(separator, parts));
+            }
+        }
+
+        private static IEnumerable<string> GetMacArm64LibVlcCandidatePaths()
+        {
+            yield return "/Applications/VLC.app/Contents/MacOS/lib";
+
+            foreach (string path in MacArm64LibVlcSearchPaths)
+            {
+                yield return path;
+            }
+
+            // Homebrew cask installs VLC as /opt/homebrew/Caskroom/vlc/<version>/VLC.app/Contents/MacOS/lib
+            const string caskRoot = "/opt/homebrew/Caskroom/vlc";
+            if (Directory.Exists(caskRoot))
+            {
+                string[] versionDirs;
+
+                try
+                {
+                    versionDirs = Directory.GetDirectories(caskRoot);
+                }
+                catch
+                {
+                    yield break;
+                }
+
+                foreach (string versionDir in versionDirs)
+                {
+                    string caskLibPath = Path.Combine(versionDir, "VLC.app", "Contents", "MacOS", "lib");
+                    yield return caskLibPath;
+                }
+            }
         }
 
         public async Task Play(Camera camera, bool displayAdvancedDShowDialog)
         {
             Guard.IsNotNull(camera);
+
+            if (!IsAvailable || libVLC is null || MediaPlayer is null)
+            {
+                logger.Warn("Ignoring Play request because LibVLC is not available on this platform/runtime.");
+                return;
+            }
 
             List<string> parametersList = [];
             ICommandBuilder? commandBuilder = null;
@@ -181,7 +431,7 @@ namespace CollimationCircles.Services
 
         public void TakeSnapshot()
         {
-            if (MediaPlayer.IsPlaying)
+            if (MediaPlayer?.IsPlaying == true)
             {
                 MediaPlayer.TakeSnapshot(0, $".\\{SnapshotImageFile}", 800, 600);
             }

--- a/CollimationCircles/ViewModels/CameraControlsViewModel.cs
+++ b/CollimationCircles/ViewModels/CameraControlsViewModel.cs
@@ -47,6 +47,12 @@ namespace CollimationCircles.ViewModels
         [RelayCommand]
         private void Apply()
         {
+            if (!libVLCService.IsAvailable)
+            {
+                logger.Warn("Cannot apply camera controls because LibVLC is not available.");
+                return;
+            }
+
             libVLCService.Play(Camera, false);
             logger.Info("Apply camera controls buton clicked");
         }        

--- a/CollimationCircles/ViewModels/CollimationAnalysisViewModel.cs
+++ b/CollimationCircles/ViewModels/CollimationAnalysisViewModel.cs
@@ -73,6 +73,12 @@ namespace CollimationCircles.ViewModels
         {
             Guard.IsNotNull(libVLCService);
 
+            if (!libVLCService.IsAvailable)
+            {
+                logger.Warn("Cannot take snapshot because LibVLC is not available.");
+                return;
+            }
+
             if (!IsImageLoaded)
             {
                 DialogService.ShowMessageBoxAsync(null,

--- a/CollimationCircles/ViewModels/StreamViewModel.cs
+++ b/CollimationCircles/ViewModels/StreamViewModel.cs
@@ -30,7 +30,7 @@ namespace CollimationCircles.ViewModels
 
         public bool CanExecutePlayPause
         {
-            get => !string.IsNullOrWhiteSpace(FullAddress) && SelectedCamera is not null;
+            get => libVLCService.IsAvailable && !string.IsNullOrWhiteSpace(FullAddress) && SelectedCamera is not null;
         }
 
         [ObservableProperty]
@@ -100,7 +100,7 @@ namespace CollimationCircles.ViewModels
             logger.Trace($"MediaPlayer opening");
 
             ShowWebCamStream();
-            IsPlaying = libVLCService.MediaPlayer.IsPlaying;
+            IsPlaying = libVLCService.MediaPlayer?.IsPlaying == true;
             ControlsEnabled = false;
         }
 
@@ -109,7 +109,7 @@ namespace CollimationCircles.ViewModels
             Guard.IsNotNull(SelectedCamera);
 
             logger.Trace($"MediaPlayer playing");
-            IsPlaying = libVLCService.MediaPlayer.IsPlaying;
+            IsPlaying = libVLCService.MediaPlayer?.IsPlaying == true;
             ControlsEnabled = IsPlaying;
         }
 
@@ -118,7 +118,7 @@ namespace CollimationCircles.ViewModels
             logger.Trace($"MediaPlayer closed");
 
             CloseWebCamStream();
-            IsPlaying = libVLCService.MediaPlayer.IsPlaying;
+            IsPlaying = libVLCService.MediaPlayer?.IsPlaying == true;
             ControlsEnabled = false;
         }
 
@@ -126,6 +126,12 @@ namespace CollimationCircles.ViewModels
         private void PlayPause()
         {
             Guard.IsNotNull(SelectedCamera);
+
+            if (!libVLCService.IsAvailable)
+            {
+                logger.Warn("Play requested but LibVLC is not available.");
+                return;
+            }
 
             if (libVLCService.MediaPlayer != null)
             {

--- a/CollimationCircles/Views/StreamView.axaml.cs
+++ b/CollimationCircles/Views/StreamView.axaml.cs
@@ -36,7 +36,10 @@ namespace CollimationCircles.Views
 
             if (videoViewer != null)
             {
-                videoViewer.MediaPlayer = mp;
+                if (mp is not null)
+                {
+                    videoViewer.MediaPlayer = mp;
+                }
 
                 UpdateWindowPosition();
             }

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ For example:
 ```curl -LO https://github.com/sajmons/CollimationCircles/releases/download/version-3.1.0/5-CollimationCircles-3.1.0-osx-x64.tar.gz```
 4. When the download finishes, extract the archive:
 ```tar -xzf 5-CollimationCircles-3.1.0-osx-x64.tar.gz```
-5. You should now see the CollimationCircles.app bundle. Run it with:
+5. Remove the downloaded app quarantine attribute:
+```xattr -d com.apple.quarantine CollimationCircles.app/```
+6. Ensure the app bundle files are executable:
+```chmod -R +x CollimationCircles.app/```
+7. You should now see the CollimationCircles.app bundle. Run it with:
 ```open CollimationCircles.app```
 
 ## Instalation on Linux
@@ -168,7 +172,74 @@ dotnet --info
 ```
 
 ### macOS
-https://learn.microsoft.com/en-us/dotnet/core/install/macos
+Use Homebrew and install .NET 9 + VLC first.
+
+1. Install Homebrew (if needed):
+```
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+2. Install required tools and runtime dependencies:
+```
+brew update
+brew install git dotnet@9 dotnet-runtime@9 vlc
+```
+3. Use the .NET 9 binary directly (no global PATH change):
+```
+DOTNET9=/opt/homebrew/opt/dotnet@9/libexec/dotnet
+```
+4. Verify installation:
+```
+$DOTNET9 --info
+$DOTNET9 --list-sdks
+$DOTNET9 --list-runtimes
+```
+
+For this project on Apple Silicon, these commands are recommended from repository root:
+
+```
+git clone https://github.com/sajmons/CollimationCircles.git
+cd CollimationCircles
+```
+
+Restore/build/run:
+```
+$DOTNET9 restore ./CollimationCircles/CollimationCircles.csproj -r osx-arm64
+$DOTNET9 build ./CollimationCircles/CollimationCircles.csproj -f net9.0
+$DOTNET9 run --project ./CollimationCircles/CollimationCircles.csproj -f net9.0
+```
+
+Notes:
+- On macOS arm64, the app now bootstraps VLC environment variables automatically at startup.
+- VLC should be installed as an app bundle (for example in /Applications/VLC.app, or via Homebrew cask path).
+- If VLC/libVLC is missing or incompatible, the app starts in degraded mode and shows a compatibility message.
+
+Publish a local release build (self-contained):
+```
+$DOTNET9 publish ./CollimationCircles/CollimationCircles.csproj \
+  -c Release -f net9.0 -r osx-arm64 \
+  --self-contained true \
+  -p:PublishSingleFile=true \
+  -p:PublishReadyToRun=true \
+  -o ./artifacts/publish/osx-arm64
+```
+
+Run published binary:
+```
+./artifacts/publish/osx-arm64/CollimationCircles
+```
+
+Create a tar.gz package for distribution:
+```
+mkdir -p ./artifacts/release
+tar -czf ./artifacts/release/CollimationCircles-net9.0-osx-arm64.tar.gz -C ./artifacts/publish/osx-arm64 .
+```
+
+Optional quick check before publishing:
+```
+$DOTNET9 clean ./CollimationCircles/CollimationCircles.csproj
+$DOTNET9 restore ./CollimationCircles/CollimationCircles.csproj -r osx-arm64
+$DOTNET9 build ./CollimationCircles/CollimationCircles.csproj -c Release -f net9.0
+```
 
 ## Build and publish on Windows
 


### PR DESCRIPTION
Fixes macOS arm64 startup/runtime failures when LibVLC is not discoverable or not fully compatible by introducing a bootstrap + fallback loading strategy and safe degraded behavior.

What changed:

- Added process-level macOS arm64 VLC bootstrap in Program.cs: discovers VLC app paths, validates required env vars, relaunches once with DYLD/VLC paths, and supports both apphost and dotnet-run (.dll) execution.

- Extended LibVLC service contract with IsAvailable and nullable MediaPlayer to represent unavailable media runtime explicitly.

- Reworked LibVLC initialization: arm64 fallback path probing, native preloading (libvlccore/libvlc), env path merging, candidate path scanning (/Applications + Homebrew/Caskroom), guarded default initialization, and clearer logs.

- Added runtime guards to prevent null/media calls when LibVLC is unavailable (play, snapshot, control application, stream state updates, DShow control writes, stream view binding).

- Added user-facing compatibility dialog in App startup (modal, owner-centered, always on top, readable opaque background) when media runtime is unavailable, while still letting the app launch.

- Added localization resources for compatibility title/body in en-US, fr-FR, de-DE, and sl-SI.

- Updated .gitignore to ignore generated state/build artifacts (including appstate.json and artifacts/bin outputs) to keep commits clean.

Behavior fixed:

- App no longer hard-fails on macOS arm64 when LibVLC native libs are missing/misconfigured.

- Application now starts in degraded mode with explicit user feedback instead of crashing or silently failing video features.

- Play/pause/snapshot/control paths no longer throw due to absent MediaPlayer.

- dotnet run relaunch path now works correctly by launching through dotnet host when needed.

Fix #34

**Not tested yet, except the popup**