### PR TITLE
Fixes #40: App crashes on Linux when rpicam-vid is not installed

### DIFF
--- a/CollimationCircles/CollimationCircles.csproj
+++ b/CollimationCircles/CollimationCircles.csproj
@@ -11,8 +11,8 @@
     <PackageProjectUrl>https://github.com/sajmons/CollimationCircles</PackageProjectUrl>
     <RepositoryUrl>https://github.com/sajmons/CollimationCircles</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>4.1.0</Version>
-    <InformationalVersion>4.1.0</InformationalVersion>
+    <Version>4.1.1</Version>
+    <InformationalVersion>4.1.1</InformationalVersion>
     <Authors>Simon Šander</Authors>
     <Product>Collimation Circles</Product>
     <Copyright>Copyright © 2023</Copyright>

--- a/CollimationCircles/Program.cs
+++ b/CollimationCircles/Program.cs
@@ -26,6 +26,11 @@ namespace CollimationCircles
         [STAThread]
         public static void Main(string[] args)
         {
+            // Disable the NLog console target when stdout is not connected to a terminal.
+            // Without this, the pipe buffer (~64 KB) fills from verbose logging and every
+            // subsequent log call blocks indefinitely, making the window appear frozen.
+            ConfigureLogging();
+
             AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
             {
                 logger.Fatal($"Unhandled exception: {e.ExceptionObject}");
@@ -227,6 +232,36 @@ namespace CollimationCircles
             }
 
             return string.Join(separator, parts);
+        }
+
+        /// <summary>
+        /// Disables the NLog console (stdout) log target when the process stdout is not
+        /// connected to a terminal. Writing to a redirected stdout whose reader has stopped
+        /// draining will block once the pipe buffer is full, freezing the entire process.
+        /// </summary>
+        private static void ConfigureLogging()
+        {
+            if (!Console.IsOutputRedirected)
+            {
+                return;
+            }
+
+            var config = NLog.LogManager.Configuration;
+            if (config is null)
+            {
+                return;
+            }
+
+            foreach (var rule in config.LoggingRules)
+            {
+                var toRemove = rule.Targets.Where(t => t.Name == "logconsole").ToList();
+                foreach (var t in toRemove)
+                {
+                    rule.Targets.Remove(t);
+                }
+            }
+
+            NLog.LogManager.ReconfigExistingLoggers();
         }
 
         /// <summary>

--- a/CollimationCircles/Services/AppService.cs
+++ b/CollimationCircles/Services/AppService.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using Octokit;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -287,9 +288,22 @@ public class AppService
 
         using var process = new Process { StartInfo = startInfo };
 
-        if (!process.Start())
+        try
         {
-            logger.Warn($"Failed to start command '{fileName} {argStr}'");
+            if (!process.Start())
+            {
+                logger.Warn($"Failed to start command '{fileName} {argStr}'");
+                return (-1, string.Empty);
+            }
+        }
+        catch (Win32Exception ex) when (ex.NativeErrorCode == 2) // ENOENT / ERROR_FILE_NOT_FOUND
+        {
+            logger.Warn($"Command not found: '{fileName}'. Ensure it is installed and on the PATH.");
+            return (-1, string.Empty);
+        }
+        catch (Win32Exception ex)
+        {
+            logger.Error(ex, $"OS error starting command '{fileName} {argStr}'");
             return (-1, string.Empty);
         }
 


### PR DESCRIPTION
This code wraps the exception and returns -1 to let the UI display the correct error but I cannot test it sadly.