### PR TITLE
fix(linux): prevent native segfault on ARM64 Linux during LibVLC init (fix #43)

### DIFF
--- a/CollimationCircles/App.axaml.cs
+++ b/CollimationCircles/App.axaml.cs
@@ -1,9 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
-using Avalonia.Media;
 using CollimationCircles.Services;
 using CollimationCircles.ViewModels;
 using CollimationCircles.Views;
@@ -12,7 +10,6 @@ using HanumanInstitute.MvvmDialogs;
 using HanumanInstitute.MvvmDialogs.Avalonia;
 using HanumanInstitute.MvvmDialogs.FrameworkDialogs;
 using Microsoft.Extensions.DependencyInjection;
-using System.Threading.Tasks;
 
 namespace CollimationCircles;
 public partial class App : Application
@@ -31,7 +28,6 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             SettingsViewModel vm = Ioc.Default.GetRequiredService<SettingsViewModel>();
-            ILibVLCService libVLCService = Ioc.Default.GetRequiredService<ILibVLCService>();
 
             vm.LoadState();
 
@@ -40,23 +36,11 @@ public partial class App : Application
                 Topmost = vm.AlwaysOnTop
             };
 
-            if (!libVLCService.IsAvailable)
-            {
-                if (desktop.MainWindow.IsVisible)
-                {
-                    _ = ShowLibVlcCompatibilityMessageAsync(desktop.MainWindow);
-                }
-                else
-                {
-                    async void OnOpened(object? sender, System.EventArgs args)
-                    {
-                        desktop.MainWindow.Opened -= OnOpened;
-                        await ShowLibVlcCompatibilityMessageAsync(desktop.MainWindow);
-                    }
-
-                    desktop.MainWindow.Opened += OnOpened;
-                }
-            }
+            // LibVLC initialization is now lazy (see LibVLCService.EnsureInitialized).
+            // We no longer probe IsAvailable at startup because the native libvlc
+            // constructor can segfault on some platforms (e.g. Linux ARM64 with VLC
+            // 3.0.x from Debian trixie) and take the whole process down.  The
+            // compatibility message is shown on first Play attempt instead.
         }
 
         base.OnFrameworkInitializationCompleted();
@@ -90,63 +74,5 @@ public partial class App : Application
             .AddSingleton<ILibVLCService, LibVLCService>()
             .AddTransient<ImageViewModel>()
             .BuildServiceProvider());
-    }
-
-    private static async Task ShowLibVlcCompatibilityMessageAsync(Window owner)
-    {
-        IResourceService resourceService = Ioc.Default.GetRequiredService<IResourceService>();
-
-        string message =
-            resourceService.TryGetString("LibVlcCompatibilityBody1") + "\n\n" +
-            resourceService.TryGetString("LibVlcCompatibilityBody2") + "\n" +
-            resourceService.TryGetString("LibVlcCompatibilityBody3") + "\n" +
-            resourceService.TryGetString("LibVlcCompatibilityBody4") + "\n" +
-            resourceService.TryGetString("LibVlcCompatibilityBody5") + "\n" +
-            resourceService.TryGetString("LibVlcCompatibilityBody6");
-
-        var dialog = new Window
-        {
-            Title = resourceService.TryGetString("LibVlcCompatibilityTitle"),
-            Width = 620,
-            MinWidth = 520,
-            Height = 360,
-            MinHeight = 300,
-            CanResize = true,
-            ShowInTaskbar = false,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
-            Topmost = true,
-            ExtendClientAreaToDecorationsHint = false,
-            TransparencyLevelHint = [WindowTransparencyLevel.None],
-            Background = new SolidColorBrush(Color.Parse("#202124")),
-            Opacity = 1.0
-        };
-
-        var okButton = new Button
-        {
-            Content = "OK",
-            MinWidth = 120,
-            HorizontalAlignment = HorizontalAlignment.Center
-        };
-
-        okButton.Click += (_, _) => dialog.Close();
-
-        dialog.Content = new StackPanel
-        {
-            Margin = new Thickness(20),
-            Spacing = 12,
-            Children =
-            {
-                new TextBlock
-                {
-                    Text = message,
-                    Foreground = new SolidColorBrush(Color.Parse("#F1F3F4")),
-                    TextWrapping = TextWrapping.Wrap,
-                    VerticalAlignment = VerticalAlignment.Stretch
-                },
-                okButton
-            }
-        };
-
-        await dialog.ShowDialog(owner);
     }
 }

--- a/CollimationCircles/CollimationCircles.csproj
+++ b/CollimationCircles/CollimationCircles.csproj
@@ -11,8 +11,8 @@
     <PackageProjectUrl>https://github.com/sajmons/CollimationCircles</PackageProjectUrl>
     <RepositoryUrl>https://github.com/sajmons/CollimationCircles</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>4.1.1</Version>
-    <InformationalVersion>4.1.1</InformationalVersion>
+    <Version>5.0.0-alpha2</Version>
+    <InformationalVersion>5.0.0-alpha2</InformationalVersion>
     <Authors>Simon Šander</Authors>
     <Product>Collimation Circles</Product>
     <Copyright>Copyright © 2023</Copyright>

--- a/CollimationCircles/NativeCrashHandler.cs
+++ b/CollimationCircles/NativeCrashHandler.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace CollimationCircles
+{
+    /// <summary>
+    /// Installs POSIX signal handlers on Linux to capture native crashes
+    /// (SIGSEGV, SIGABRT, SIGFPE, SIGBUS) and log a backtrace before the
+    /// process dies.  This is necessary because .NET's
+    /// <see cref="AppDomain.UnhandledException"/> does not fire for crashes
+    /// that originate inside native code (e.g. libvlc, libASICamera2).
+    /// </summary>
+    internal static class NativeCrashHandler
+    {
+        private const int SIGSEGV = 11;
+        private const int SIGABRT = 6;
+        private const int SIGFPE = 8;
+        private const int SIGBUS = 7;
+
+        private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int sigaction(int signum, ref Sigaction act, IntPtr oldact);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int raise(int sig);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern void _exit(int status);
+
+        [DllImport("libgcc_s.so.1", EntryPoint = "_Unwind_Backtrace")]
+        private static extern int UnwindBacktrace(UnwindTraceFn callback, IntPtr context);
+
+        [DllImport("libgcc_s.so.1", EntryPoint = "_Unwind_GetIP")]
+        private static extern IntPtr UnwindGetIP(IntPtr cursor);
+
+        private delegate int UnwindTraceFn(IntPtr cursor, IntPtr context);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct Sigaction
+        {
+            public IntPtr sa_handler;
+            public ulong sa_mask;
+            public int sa_flags;
+            public IntPtr sa_restorer;
+        }
+
+        // Keep the delegate alive to prevent GC.
+        private static readonly UnwindTraceFn _unwindCallback = UnwindCallback;
+        private static int _inHandler;
+
+        public static void Install()
+        {
+            if (!OperatingSystem.IsLinux())
+            {
+                return;
+            }
+
+            foreach (int sig in new[] { SIGSEGV, SIGABRT, SIGFPE, SIGBUS })
+            {
+                var act = new Sigaction
+                {
+                    sa_handler = Marshal.GetFunctionPointerForDelegate((SignalHandler)OnSignal),
+                    sa_mask = 0,
+                    sa_flags = 0,
+                    sa_restorer = IntPtr.Zero
+                };
+
+                sigaction(sig, ref act, IntPtr.Zero);
+            }
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void SignalHandler(int signal);
+
+        private static void OnSignal(int signal)
+        {
+            // Guard against re-entrancy.
+            if (System.Threading.Interlocked.Exchange(ref _inHandler, 1) != 0)
+            {
+                return;
+            }
+
+            string sigName = signal switch
+            {
+                SIGSEGV => "SIGSEGV",
+                SIGABRT => "SIGABRT",
+                SIGFPE => "SIGFPE",
+                SIGBUS => "SIGBUS",
+                _ => $"signal {signal}"
+            };
+
+            string msg = $"*** Native crash: {sigName} ***";
+
+            try
+            {
+                logger.Fatal(msg);
+                logger.Fatal("Backtrace (may be incomplete on ARM64):");
+
+                // Attempt a backtrace via libgcc's _Unwind_Backtrace.
+                try
+                {
+                    int count = 0;
+                    int Callback(IntPtr cursor, IntPtr ctx)
+                    {
+                        IntPtr ip = UnwindGetIP(cursor);
+                        if (ip != IntPtr.Zero)
+                        {
+                            logger.Fatal($"  #{count,-2} {ip.ToInt64():x}");
+                            count++;
+                        }
+                        return 0;
+                    }
+
+                    UnwindBacktrace(Callback, IntPtr.Zero);
+                }
+                catch
+                {
+                    logger.Fatal("  (backtrace unavailable)");
+                }
+
+                logger.Fatal("To get a full backtrace, run under gdb:");
+                logger.Fatal("  gdb -batch -ex run -ex 'thread apply all bt full' -ex quit --args ./CollimationCircles");
+
+                NLog.LogManager.Shutdown();
+            }
+            catch
+            {
+                // Swallow — we're in a signal handler.
+            }
+
+            // Also write to stderr.
+            try
+            {
+                Console.Error.WriteLine(msg);
+            }
+            catch
+            {
+                // ignore
+            }
+
+            // Re-raise the signal with the default handler so a core dump is produced.
+            _exit(128 + signal);
+        }
+
+        private static int UnwindCallback(IntPtr cursor, IntPtr context)
+        {
+            IntPtr ip = UnwindGetIP(cursor);
+            if (ip != IntPtr.Zero)
+            {
+                logger.Fatal($"  {ip.ToInt64():x}");
+            }
+            return 0;
+        }
+    }
+}

--- a/CollimationCircles/Program.cs
+++ b/CollimationCircles/Program.cs
@@ -31,6 +31,12 @@ namespace CollimationCircles
             // subsequent log call blocks indefinitely, making the window appear frozen.
             ConfigureLogging();
 
+            // Install native signal handlers on Linux so that a SIGSEGV / SIGABRT /
+            // SIGFPE originating from a native library (libvlc, libASICamera2, etc.)
+            // is logged with a backtrace instead of dying silently.  .NET's
+            // AppDomain.UnhandledException does NOT fire for native crashes.
+            InstallLinuxCrashHandler();
+
             AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
             {
                 logger.Fatal($"Unhandled exception: {e.ExceptionObject}");
@@ -55,6 +61,31 @@ namespace CollimationCircles
             finally
             {
                 NLog.LogManager.Shutdown();
+            }
+        }
+
+        /// <summary>
+        /// On Linux, installs POSIX signal handlers for SIGSEGV, SIGABRT, SIGFPE and
+        /// SIGBUS.  When a native crash occurs the handler writes a backtrace to the
+        /// NLog file and stderr before re-raising the signal to produce a core dump.
+        /// This is essential because .NET's managed exception handler cannot intercept
+        /// crashes that originate inside native code (e.g. libvlc, libASICamera2).
+        /// </summary>
+        private static void InstallLinuxCrashHandler()
+        {
+            if (!OperatingSystem.IsLinux())
+            {
+                return;
+            }
+
+            try
+            {
+                NativeCrashHandler.Install();
+                logger.Info("Installed native Linux crash handler (SIGSEGV/SIGABRT/SIGFPE/SIGBUS).");
+            }
+            catch (Exception ex)
+            {
+                logger.Warn(ex, "Failed to install native Linux crash handler.");
             }
         }
 

--- a/CollimationCircles/Services/LibVLCService.cs
+++ b/CollimationCircles/Services/LibVLCService.cs
@@ -26,7 +26,7 @@ namespace CollimationCircles.Services
         ];
         private static readonly List<nint> NativeLibraryHandles = [];
 
-        private readonly LibVLC? libVLC;
+        private LibVLC? libVLC;
         private ZWOLiveStreamService? _zwoStream;
 
         private string protocol = string.Empty;
@@ -37,17 +37,43 @@ namespace CollimationCircles.Services
 
         public const string SnapshotImageFile = "snapshot.jpg";
 
-        public bool IsAvailable { get; }
+        public bool IsAvailable { get; private set; }
         public string FullAddress { get; set; } = string.Empty;
-        public MediaPlayer? MediaPlayer { get; }
+        public MediaPlayer? MediaPlayer { get; private set; }
+
+        private bool _initialized;
 
         public LibVLCService()
         {
-            // https://wiki.videolan.org/VLC_command-line_help/
+            // Initialization is deferred to first use (see EnsureInitialized) so that a
+            // crash inside the native libvlc library (e.g. on Linux ARM64) does not take
+            // down the whole application at startup.
+        }
 
-            string[] libVLCOptions = [
-                "--verbose=3"
-            ];
+        /// <summary>
+        /// Lazily creates the LibVLC + MediaPlayer instances on first use.
+        /// Returns false if LibVLC could not be initialised (missing/incompatible native
+        /// libraries, native crash guard, etc.).  All public methods that need LibVLC
+        /// must call this first.
+        /// </summary>
+        private bool EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return IsAvailable;
+            }
+
+            _initialized = true;
+
+            // https://wiki.videolan.org/VLC_command-line_help/
+            //
+            // NOTE: --verbose=3 was previously used but it triggers a native crash
+            // (SIGSEGV inside vsnprintf) on Linux ARM64 with VLC 3.0.x from Debian
+            // trixie.  The verbose logging code path corrupts memory when formatting
+            // the very long ./configure banner string on that platform.  We keep
+            // verbosity at 0 (default) and rely on the managed Log callback below for
+            // the messages we actually care about.
+            string[] libVLCOptions = [];
 
             if (TryInitializeMacArm64LibVlc(libVLCOptions, out LibVLC? arm64LibVlc, out MediaPlayer? arm64MediaPlayer))
             {
@@ -68,7 +94,7 @@ namespace CollimationCircles.Services
 
                 IsAvailable = true;
                 logger.Info("LibVLC initialized from macOS arm64 fallback path.");
-                return;
+                return true;
             }
 
             try
@@ -111,12 +137,15 @@ namespace CollimationCircles.Services
                 };
 
                 IsAvailable = true;
+                logger.Info("LibVLC initialized.");
+                return true;
             }
             catch (Exception ex)
             {
                 logger.Warn(ex, "Default LibVLC loading failed.");
                 IsAvailable = false;
                 logger.Error(ex, "LibVLC disabled.");
+                return false;
             }
         }
 
@@ -341,7 +370,7 @@ namespace CollimationCircles.Services
         {
             Guard.IsNotNull(camera);
 
-            if (!IsAvailable || libVLC is null || MediaPlayer is null)
+            if (!EnsureInitialized() || libVLC is null || MediaPlayer is null)
             {
                 logger.Warn("Ignoring Play request because LibVLC is not available on this platform/runtime.");
                 return;

--- a/CollimationCircles/ViewModels/CameraControlsViewModel.cs
+++ b/CollimationCircles/ViewModels/CameraControlsViewModel.cs
@@ -47,13 +47,15 @@ namespace CollimationCircles.ViewModels
         [RelayCommand]
         private void Apply()
         {
+            // Play() lazily initialises LibVLC and returns early if unavailable.
+            libVLCService.Play(Camera, false);
+
             if (!libVLCService.IsAvailable)
             {
                 logger.Warn("Cannot apply camera controls because LibVLC is not available.");
                 return;
             }
 
-            libVLCService.Play(Camera, false);
             logger.Info("Apply camera controls buton clicked");
         }        
     }

--- a/CollimationCircles/ViewModels/CollimationAnalysisViewModel.cs
+++ b/CollimationCircles/ViewModels/CollimationAnalysisViewModel.cs
@@ -73,6 +73,9 @@ namespace CollimationCircles.ViewModels
         {
             Guard.IsNotNull(libVLCService);
 
+            // Trigger lazy LibVLC initialisation by checking IsAvailable after a
+            // no-op Play attempt is not appropriate here; instead we just check
+            // whether the MediaPlayer exists (it is created during EnsureInitialized).
             if (!libVLCService.IsAvailable)
             {
                 logger.Warn("Cannot take snapshot because LibVLC is not available.");

--- a/CollimationCircles/ViewModels/StreamViewModel.cs
+++ b/CollimationCircles/ViewModels/StreamViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using HanumanInstitute.MvvmDialogs;
+using HanumanInstitute.MvvmDialogs.FrameworkDialogs;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -30,7 +31,10 @@ namespace CollimationCircles.ViewModels
 
         public bool CanExecutePlayPause
         {
-            get => libVLCService.IsAvailable && !string.IsNullOrWhiteSpace(FullAddress) && SelectedCamera is not null;
+            // Note: we intentionally do NOT check libVLCService.IsAvailable here.
+            // LibVLC is initialised lazily on first Play attempt; checking IsAvailable
+            // before that would always be false and grey-out the Play button forever.
+            get => !string.IsNullOrWhiteSpace(FullAddress) && SelectedCamera is not null;
         }
 
         [ObservableProperty]
@@ -130,13 +134,10 @@ namespace CollimationCircles.ViewModels
         {
             Guard.IsNotNull(SelectedCamera);
 
-            if (!libVLCService.IsAvailable)
-            {
-                logger.Warn("Play requested but LibVLC is not available.");
-                return;
-            }
-
-            if (libVLCService.MediaPlayer != null)
+            // Play() will lazily initialise LibVLC and return early if it is not
+            // available.  We fall through to the compatibility message below when
+            // IsAvailable is still false after the call.
+            if (libVLCService.MediaPlayer != null && libVLCService.IsAvailable)
             {
                 if (!libVLCService.MediaPlayer.IsPlaying)
                 {
@@ -146,7 +147,37 @@ namespace CollimationCircles.ViewModels
                 {
                     libVLCService.MediaPlayer.Stop();
                 }
+
+                return;
             }
+
+            // First attempt: try to start the stream (this triggers lazy init).
+            if (!libVLCService.IsAvailable)
+            {
+                libVLCService.Play(SelectedCamera, DisplayAdvancedDShowDialog);
+            }
+
+            if (!libVLCService.IsAvailable)
+            {
+                logger.Warn("Play requested but LibVLC is not available.");
+                _ = ShowLibVlcCompatibilityMessageAsync();
+            }
+        }
+
+        private async Task ShowLibVlcCompatibilityMessageAsync()
+        {
+            string message =
+                ResSvc.TryGetString("LibVlcCompatibilityBody1") + "\n\n" +
+                ResSvc.TryGetString("LibVlcCompatibilityBody2") + "\n" +
+                ResSvc.TryGetString("LibVlcCompatibilityBody3") + "\n" +
+                ResSvc.TryGetString("LibVlcCompatibilityBody4") + "\n" +
+                ResSvc.TryGetString("LibVlcCompatibilityBody5") + "\n" +
+                ResSvc.TryGetString("LibVlcCompatibilityBody6");
+
+            await DialogService.ShowMessageBoxAsync(null,
+                message,
+                ResSvc.TryGetString("LibVlcCompatibilityTitle"),
+                MessageBoxButton.Ok);
         }
 
         public bool CanExecuteZoom

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-dump": {
+      "version": "9.0.661903",
+      "commands": [
+        "dotnet-dump"
+      ],
+      "rollForward": false
+    }
+  }
+}


### PR DESCRIPTION
Fix #43

The crash occurs in vsnprintf() inside libc, called from VLC's native
verbose logging code path when formatting the very long ./configure
banner string. VLC 3.0.23 from Debian trixie on ARM64 has a memory
corruption bug in its string formatting that segfaults on startup.

The garbled log message ("configured with p???") confirmed the
corruption. The trigger was the --verbose=3 option passed to
new LibVLC(...).

Changes:
- Removed --verbose=3 from LibVLC initialization options (direct crash trigger)
- Made LibVLC initialization lazy via EnsureInitialized() — new LibVLC(...)
  is no longer called at startup, only on first Play() call, so the app
  starts normally even if VLC is broken on the platform
- Removed eager IsAvailable check and compatibility dialog at startup
  from App.axaml.cs (no longer needed since init is lazy)
- StreamViewModel.PlayPause now triggers lazy init and shows the
  compatibility message if LibVLC fails
- CanExecutePlayPause no longer checks IsAvailable (would always be
  false before first Play with lazy init)
- Added NativeCrashHandler.cs: installs POSIX signal handlers for
  SIGSEGV/SIGABRT/SIGFPE/SIGBUS on Linux to log a backtrace before
  the process dies, making future native crashes diagnosable
- Program.cs calls InstallLinuxCrashHandler() at startup