### PR TITLE
feat: bypass LibVLC for ZWO cameras with direct rendering (=> collimation-helper)

### DIFF
--- a/CollimationCircles/App.axaml.cs
+++ b/CollimationCircles/App.axaml.cs
@@ -72,6 +72,7 @@ public partial class App : Application
             .AddSingleton<IKeyHandlingService, KeyHandlingService>()
             .AddSingleton<ICameraControlService, CameraControlService>()
             .AddSingleton<ILibVLCService, LibVLCService>()
+            .AddSingleton<IZwoFrameSource, ZwoFrameSource>()
             .AddTransient<ImageViewModel>()
             .BuildServiceProvider());
     }

--- a/CollimationCircles/Services/IZwoFrameSource.cs
+++ b/CollimationCircles/Services/IZwoFrameSource.cs
@@ -1,0 +1,35 @@
+using CollimationCircles.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace CollimationCircles.Services
+{
+    /// <summary>
+    /// Provides direct frame delivery from a ZWO ASI camera, bypassing LibVLC.
+    /// The <see cref="FrameReady"/> event fires for every captured frame with
+    /// JPEG-encoded image data.
+    /// </summary>
+    internal interface IZwoFrameSource
+    {
+        /// <summary>True while a ZWO camera stream is active.</summary>
+        bool IsStreaming { get; }
+
+        /// <summary>Width of the captured ROI in pixels (0 until stream starts).</summary>
+        int FrameWidth { get; }
+
+        /// <summary>Height of the captured ROI in pixels (0 until stream starts).</summary>
+        int FrameHeight { get; }
+
+        /// <summary>
+        /// Fired on the capture thread for every new frame. The byte array
+        /// contains JPEG-encoded image data of size <see cref="FrameWidth"/> × <see cref="FrameHeight"/>.
+        /// </summary>
+        event Action<byte[], int, int>? FrameReady;
+
+        /// <summary>Opens the ZWO camera and starts the capture loop.</summary>
+        Task<bool> StartAsync(Camera camera);
+
+        /// <summary>Stops the capture loop and closes the camera.</summary>
+        void Stop();
+    }
+}

--- a/CollimationCircles/Services/LibVLCService.cs
+++ b/CollimationCircles/Services/LibVLCService.cs
@@ -3,6 +3,7 @@ using CollimationCircles.Messages;
 using CollimationCircles.Models;
 using Avalonia.Threading;
 using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Messaging;
 using LibVLCSharp.Shared;
 using Octokit;
@@ -378,28 +379,36 @@ namespace CollimationCircles.Services
         {
             Guard.IsNotNull(camera);
 
+            if (camera.APIType == APIType.Zwo)
+            {
+                // ZWO cameras bypass LibVLC entirely — frames are rendered directly
+                // by FrameRenderer via IZwoFrameSource.
+                var zwoFrameSource = Ioc.Default.GetRequiredService<IZwoFrameSource>();
+
+                StopZwoStream();
+                zwoFrameSource.Stop();
+
+                bool started = await zwoFrameSource.StartAsync(camera);
+
+                if (!started)
+                {
+                    logger.Error($"Failed to start ZWO direct stream for camera '{camera.Name}'");
+                    SendCameraStateOnUIThread(CameraState.Stopped);
+                    return;
+                }
+
+                FullAddress = $"zwo-direct://{camera.Path}";
+                logger.Info($"ZWO direct stream started for camera '{camera.Name}' ({zwoFrameSource.FrameWidth}×{zwoFrameSource.FrameHeight})");
+
+                SendCameraStateOnUIThread(CameraState.Opening);
+                SendCameraStateOnUIThread(CameraState.Playing);
+                return;
+            }
+
             if (!EnsureInitialized() || libVLC is null || MediaPlayer is null)
             {
                 logger.Warn("Ignoring Play request because LibVLC is not available on this platform/runtime.");
                 return;
-            }
-
-            if (camera.APIType == APIType.Zwo)
-            {
-                // Start the MJPEG capture service for the ZWO camera and let
-                // LibVLC play the resulting local HTTP stream.
-                StopZwoStream();
-                _zwoStream = new ZWOLiveStreamService();
-                bool started = await _zwoStream.StartAsync(camera);
-
-                if (!started)
-                {
-                    logger.Error($"Failed to start ZWO live stream for camera '{camera.Name}'");
-                    _zwoStream = null;
-                    return;
-                }
-
-                FullAddress = $"http://localhost:{_zwoStream.Port}/";
             }
 
             List<string> parametersList = [];
@@ -554,6 +563,15 @@ namespace CollimationCircles.Services
                 _zwoStream.Stop();
                 _zwoStream.Dispose();
                 _zwoStream = null;
+            }
+
+            try
+            {
+                Ioc.Default.GetRequiredService<IZwoFrameSource>().Stop();
+            }
+            catch (Exception ex)
+            {
+                logger.Debug(ex, "Error stopping ZwoFrameSource");
             }
         }
     }

--- a/CollimationCircles/Services/ZWOLiveStreamService.cs
+++ b/CollimationCircles/Services/ZWOLiveStreamService.cs
@@ -16,8 +16,10 @@ namespace CollimationCircles.Services
 {
     /// <summary>
     /// Captures frames from a ZWO ASI camera using the ASI SDK and serves them
-    /// as an MJPEG stream over a local HTTP listener.  LibVLC then plays the
-    /// resulting http://localhost:{Port}/ URL.
+    /// as JPEG frames.  When <see cref="EnableDirectRendering"/> is true, frames
+    /// are delivered via <see cref="FrameReady"/> for direct rendering by
+    /// <c>FrameRenderer</c>.  Otherwise, frames are served as an MJPEG stream
+    /// over a local HTTP listener for LibVLC playback.
     /// </summary>
     internal sealed class ZWOLiveStreamService : IDisposable
     {
@@ -42,8 +44,31 @@ namespace CollimationCircles.Services
 
         private bool _disposed;
         private bool _running;
+        private bool _isColorCamera;
+        private ZWOASICameraInterop.ASI_IMG_TYPE _imgType;
 
         public int Port { get; private set; }
+
+        /// <summary>Width of the captured ROI in pixels.</summary>
+        public int FrameWidth => _width;
+
+        /// <summary>Height of the captured ROI in pixels.</summary>
+        public int FrameHeight => _height;
+
+        /// <summary>
+        /// When true, the MJPEG HTTP server is skipped and frames are delivered
+        /// exclusively via <see cref="FrameReady"/>.  This avoids the LibVLC
+        /// middleman and lets the caller render directly to an Avalonia Image.
+        /// </summary>
+        public bool EnableDirectRendering { get; set; }
+
+        /// <summary>
+        /// Fired on the capture thread for every new frame when
+        /// <see cref="EnableDirectRendering"/> is true.  The byte array contains
+        /// JPEG-encoded image data of size
+        /// <see cref="FrameWidth"/> × <see cref="FrameHeight"/>.
+        /// </summary>
+        public event Action<byte[], int, int>? FrameReady;
 
         // ------------------------------------------------------------------ //
         //  Public static helpers                                               //
@@ -76,9 +101,12 @@ namespace CollimationCircles.Services
             var info = new ZWOASICameraInterop.ASI_CAMERA_INFO();
             ZWOASICameraInterop.ASIGetCameraProperty(ref info, camera.Index);
 
-            // Cap at 1280×960 for a responsive preview; must be multiples of 8
-            _width  = (Math.Min((int)info.MaxWidth,  1280) / 8) * 8;
-            _height = (Math.Min((int)info.MaxHeight,  960) / 8) * 8;
+            logger.Info($"ZWO camera info: MaxWidth={info.MaxWidth}, MaxHeight={info.MaxHeight}, IsColorCam={info.IsColorCam}, BitDepth={info.BitDepth}, PixelSize={info.PixelSize}");
+
+            // Use the camera's full native resolution (no ROI cropping).
+            // The display layer handles scaling/zoom.  Must be multiples of 8.
+            _width  = ((int)info.MaxWidth  / 8) * 8;
+            _height = ((int)info.MaxHeight / 8) * 8;
 
             if (_width <= 0 || _height <= 0)
             {
@@ -87,7 +115,7 @@ namespace CollimationCircles.Services
                 _height = 480;
             }
 
-            logger.Info($"ZWO stream: opening camera {_cameraId}, ROI {_width}×{_height}");
+            logger.Info($"ZWO stream: opening camera {_cameraId}, full resolution {_width}×{_height}");
 
             // Open and initialise the camera
             int r = ZWOASICameraInterop.ASIOpenCamera(_cameraId);
@@ -106,15 +134,31 @@ namespace CollimationCircles.Services
             // - Exposure: auto mode.
             ApplyStartupControls(camera);
 
-            // Y8 = 8-bit luminance (grayscale) — works on all ASI cameras
-            r = ZWOASICameraInterop.ASISetROIFormat(_cameraId, _width, _height, 1,
-                ZWOASICameraInterop.ASI_IMG_TYPE.ASI_IMG_Y8);
+            // RGB24 = 3 bytes/pixel (R,G,B interleaved). The ZWO SDK does the
+            // Bayer demosaicing on-chip/on-host and returns ready-to-display RGB.
+            // For mono cameras, fall back to Y8 (grayscale, 1 byte/pixel).
+            var imgType = info.IsColorCam != 0
+                ? ZWOASICameraInterop.ASI_IMG_TYPE.ASI_IMG_RGB24
+                : ZWOASICameraInterop.ASI_IMG_TYPE.ASI_IMG_Y8;
+
+            r = ZWOASICameraInterop.ASISetROIFormat(_cameraId, _width, _height, 1, imgType);
             if (r != 0)
             {
-                logger.Error($"ASISetROIFormat failed ({r})");
-                ZWOASICameraInterop.ASICloseCamera(_cameraId);
-                return false;
+                logger.Error($"ASISetROIFormat failed ({r}) with {imgType}, trying Y8");
+                // Fallback to Y8 (grayscale) which works on all cameras.
+                imgType = ZWOASICameraInterop.ASI_IMG_TYPE.ASI_IMG_Y8;
+                r = ZWOASICameraInterop.ASISetROIFormat(_cameraId, _width, _height, 1, imgType);
+                if (r != 0)
+                {
+                    logger.Error($"ASISetROIFormat failed ({r}) with Y8 fallback");
+                    ZWOASICameraInterop.ASICloseCamera(_cameraId);
+                    return false;
+                }
             }
+
+            _isColorCamera = imgType == ZWOASICameraInterop.ASI_IMG_TYPE.ASI_IMG_RGB24;
+            _imgType = imgType;
+            logger.Info($"ZWO using image format: {imgType}, color={_isColorCamera}");
 
             r = ZWOASICameraInterop.ASIStartVideoCapture(_cameraId);
             if (r != 0)
@@ -124,15 +168,18 @@ namespace CollimationCircles.Services
                 return false;
             }
 
-            // Bind an HTTP listener on a free local port
-            Port = FindFreePort();
-            _listener = new HttpListener();
-            _listener.Prefixes.Add($"http://localhost:{Port}/");
-            _listener.Start();
-
             _cts = new CancellationTokenSource();
             _captureTask = Task.Run(() => CaptureLoop(_cts.Token));
-            _serverTask  = Task.Run(() => ServerLoop(_cts.Token));
+
+            if (!EnableDirectRendering)
+            {
+                // Bind an HTTP listener on a free local port (LibVLC path)
+                Port = FindFreePort();
+                _listener = new HttpListener();
+                _listener.Prefixes.Add($"http://localhost:{Port}/");
+                _listener.Start();
+                _serverTask = Task.Run(() => ServerLoop(_cts.Token));
+            }
 
             lock (_activeStreamsLock)
             {
@@ -141,7 +188,10 @@ namespace CollimationCircles.Services
 
             _running = true;
 
-            logger.Info($"ZWO MJPEG stream running at http://localhost:{Port}/  (camera {_cameraId})");
+            if (EnableDirectRendering)
+                logger.Info($"ZWO direct-render stream running (camera {_cameraId}, {_width}×{_height})");
+            else
+                logger.Info($"ZWO MJPEG stream running at http://localhost:{Port}/  (camera {_cameraId})");
             return await Task.FromResult(true);
         }
 
@@ -248,7 +298,9 @@ namespace CollimationCircles.Services
 
         private void CaptureLoop(CancellationToken ct)
         {
-            int bufferSize = _width * _height; // Y8 = 1 byte per pixel
+            // RGB24 = 3 bytes/pixel, Y8 = 1 byte/pixel
+            int bytesPerPixel = _isColorCamera ? 3 : 1;
+            int bufferSize = _width * _height * bytesPerPixel;
             IntPtr nativeBuffer = Marshal.AllocHGlobal(bufferSize);
 
             try
@@ -268,11 +320,20 @@ namespace CollimationCircles.Services
                     byte[] raw = new byte[bufferSize];
                     Marshal.Copy(nativeBuffer, raw, 0, bufferSize);
 
-                    byte[] jpeg = EncodeGrayscaleToJpeg(raw, _width, _height);
+                    byte[] jpeg = _isColorCamera
+                        ? EncodeColorToJpeg(raw, _width, _height)
+                        : EncodeGrayscaleToJpeg(raw, _width, _height);
 
-                    lock (_frameLock)
+                    if (EnableDirectRendering)
                     {
-                        _latestJpeg = jpeg;
+                        FrameReady?.Invoke(jpeg, _width, _height);
+                    }
+                    else
+                    {
+                        lock (_frameLock)
+                        {
+                            _latestJpeg = jpeg;
+                        }
                     }
                 }
             }
@@ -295,6 +356,19 @@ namespace CollimationCircles.Services
             image.Format = MagickFormat.Jpeg;
             image.Quality = 80;
 
+            return image.ToByteArray();
+        }
+
+        /// <summary>
+        /// Encodes RGB24 raw data (3 bytes/pixel, B-G-R interleaved) to JPEG.
+        /// The ZWO SDK returns RGB24 in BGR order.
+        /// </summary>
+        private static byte[] EncodeColorToJpeg(byte[] rawRGB24, int width, int height)
+        {
+            // ZWO SDK RGB24 is BGR interleaved — read as RGB with 3 char channels.
+            using var image = new MagickImage(rawRGB24, new PixelReadSettings((uint)width, (uint)height, StorageType.Char, "RGB"));
+            image.Format = MagickFormat.Jpeg;
+            image.Quality = 80;
             return image.ToByteArray();
         }
 

--- a/CollimationCircles/Services/ZwoFrameSource.cs
+++ b/CollimationCircles/Services/ZwoFrameSource.cs
@@ -1,0 +1,63 @@
+using CollimationCircles.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace CollimationCircles.Services
+{
+    /// <summary>
+    /// Adapter that wraps <see cref="ZWOLiveStreamService"/> in direct-rendering
+    /// mode and exposes it through <see cref="IZwoFrameSource"/>.
+    /// Registered as a singleton so <c>StreamView</c> and <c>LibVLCService</c>
+    /// share the same instance.
+    /// </summary>
+    internal sealed class ZwoFrameSource : IZwoFrameSource, IDisposable
+    {
+        private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+        private ZWOLiveStreamService? _stream;
+
+        public bool IsStreaming => _stream != null;
+
+        public int FrameWidth => _stream?.FrameWidth ?? 0;
+        public int FrameHeight => _stream?.FrameHeight ?? 0;
+
+        public event Action<byte[], int, int>? FrameReady;
+
+        public async Task<bool> StartAsync(Camera camera)
+        {
+            Stop();
+
+            _stream = new ZWOLiveStreamService { EnableDirectRendering = true };
+            _stream.FrameReady += OnFrameReady;
+
+            bool started = await _stream.StartAsync(camera);
+            if (!started)
+            {
+                logger.Error($"Failed to start ZWO direct stream for camera '{camera.Name}'");
+                _stream.FrameReady -= OnFrameReady;
+                _stream = null;
+            }
+
+            return started;
+        }
+
+        public void Stop()
+        {
+            if (_stream is null) return;
+
+            _stream.FrameReady -= OnFrameReady;
+            _stream.Stop();
+            _stream.Dispose();
+            _stream = null;
+        }
+
+        private void OnFrameReady(byte[] frame, int width, int height)
+        {
+            FrameReady?.Invoke(frame, width, height);
+        }
+
+        public void Dispose()
+        {
+            Stop();
+        }
+    }
+}

--- a/CollimationCircles/ViewModels/StreamViewModel.cs
+++ b/CollimationCircles/ViewModels/StreamViewModel.cs
@@ -104,7 +104,7 @@ namespace CollimationCircles.ViewModels
             logger.Trace($"MediaPlayer opening");
 
             ShowWebCamStream();
-            IsPlaying = libVLCService.MediaPlayer?.IsPlaying == true;
+            IsPlaying = SelectedCamera?.APIType == APIType.Zwo || libVLCService.MediaPlayer?.IsPlaying == true;
             if (SelectedCamera is not null)
             {
                 SelectedCamera.IsPlaying = IsPlaying;
@@ -116,7 +116,7 @@ namespace CollimationCircles.ViewModels
             Guard.IsNotNull(SelectedCamera);
 
             logger.Trace($"MediaPlayer playing");
-            IsPlaying = libVLCService.MediaPlayer?.IsPlaying == true;
+            IsPlaying = SelectedCamera.APIType == APIType.Zwo || libVLCService.MediaPlayer?.IsPlaying == true;
             SelectedCamera.IsPlaying = IsPlaying;
         }
 
@@ -136,6 +136,24 @@ namespace CollimationCircles.ViewModels
         private void PlayPause()
         {
             Guard.IsNotNull(SelectedCamera);
+
+            // ZWO cameras use a direct-rendering path that bypasses LibVLC entirely.
+            if (SelectedCamera.APIType == APIType.Zwo)
+            {
+                var zwoFrameSource = Ioc.Default.GetRequiredService<IZwoFrameSource>();
+
+                if (zwoFrameSource.IsStreaming)
+                {
+                    zwoFrameSource.Stop();
+                    MediaPlayer_Closed();
+                }
+                else
+                {
+                    libVLCService.Play(SelectedCamera, DisplayAdvancedDShowDialog);
+                }
+
+                return;
+            }
 
             // Play() will lazily initialise LibVLC and return early if it is not
             // available.  We fall through to the compatibility message below when

--- a/CollimationCircles/Views/FrameRenderer.cs
+++ b/CollimationCircles/Views/FrameRenderer.cs
@@ -1,0 +1,134 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using System;
+using System.IO;
+
+namespace CollimationCircles.Views
+{
+    /// <summary>
+    /// Custom control that renders JPEG frames from a ZWO camera, scaled to fill
+    /// the control bounds.  Bypasses the Avalonia Image control which does not
+    /// respect Stretch on macOS.  The JPEG is decoded at the target physical
+    /// pixel size so DrawImage can copy 1:1 without scaling.
+    /// </summary>
+    public class FrameRenderer : Control
+    {
+        private byte[]? _latestJpeg;
+        private Bitmap? _currentBitmap;
+        private double _zoom = 1.0;
+
+        public void SetJpegFrame(byte[] jpeg)
+        {
+            _latestJpeg = jpeg;
+            Dispatcher.UIThread.Post(() => InvalidateVisual());
+        }
+
+        public double Zoom
+        {
+            get => _zoom;
+            set
+            {
+                _zoom = value;
+                Dispatcher.UIThread.Post(() => InvalidateVisual());
+            }
+        }
+
+        public override void Render(DrawingContext context)
+        {
+            base.Render(context);
+
+            if (_latestJpeg is null)
+                return;
+
+            double ctrlW = Bounds.Width;
+            double ctrlH = Bounds.Height;
+            if (ctrlW <= 0 || ctrlH <= 0)
+                return;
+
+            double renderScale = 1.0;
+            try
+            {
+                if (VisualRoot is Avalonia.Controls.TopLevel tl)
+                    renderScale = tl.RenderScaling;
+            }
+            catch { }
+
+            int physW = (int)Math.Round(ctrlW * renderScale);
+            int physH = (int)Math.Round(ctrlH * renderScale);
+
+            try
+            {
+                // Probe source dimensions.
+                using var probeMs = new MemoryStream(_latestJpeg);
+                using var probe = new Bitmap(probeMs);
+                int srcW = probe.PixelSize.Width;
+                int srcH = probe.PixelSize.Height;
+                if (srcW <= 0 || srcH <= 0)
+                    return;
+
+                // Decode at the target physical pixel width.
+                int targetW;
+                if (_zoom <= 1.0)
+                {
+                    double scale = Math.Min((double)physW / srcW, (double)physH / srcH);
+                    targetW = Math.Max(1, (int)Math.Round(srcW * scale));
+                }
+                else
+                {
+                    double zoomScale = Math.Min((double)physW / srcW, (double)physH / srcH) * _zoom;
+                    targetW = Math.Max(1, (int)Math.Round(srcW * zoomScale));
+                }
+
+                using var ms = new MemoryStream(_latestJpeg);
+                var decoded = Bitmap.DecodeToWidth(ms, targetW);
+
+                // Swap bitmaps — dispose the previous one.
+                var oldBmp = _currentBitmap;
+                _currentBitmap = decoded;
+                (oldBmp as IDisposable)?.Dispose();
+
+                double dipW = decoded.PixelSize.Width / renderScale;
+                double dipH = decoded.PixelSize.Height / renderScale;
+
+                if (_zoom <= 1.0)
+                {
+                    // Center the bitmap in the control.
+                    double offsetX = (ctrlW - dipW) / 2.0;
+                    double offsetY = (ctrlH - dipH) / 2.0;
+
+                    using (context.PushTransform(Matrix.CreateTranslation(offsetX, offsetY)))
+                    {
+                        context.DrawImage(decoded,
+                            new Rect(0, 0, decoded.PixelSize.Width, decoded.PixelSize.Height),
+                            new Rect(0, 0, dipW, dipH));
+                    }
+                }
+                else
+                {
+                    // Zoom: crop center and scale to fill the control.
+                    int cropW = Math.Min(decoded.PixelSize.Width, physW);
+                    int cropH = Math.Min(decoded.PixelSize.Height, physH);
+                    int cropX = (decoded.PixelSize.Width - cropW) / 2;
+                    int cropY = (decoded.PixelSize.Height - cropH) / 2;
+
+                    double scaleX = ctrlW / (cropW / renderScale);
+                    double scaleY = ctrlH / (cropH / renderScale);
+
+                    using (context.PushTransform(Matrix.CreateScale(scaleX, scaleY)))
+                    {
+                        context.DrawImage(decoded,
+                            new Rect(cropX, cropY, cropW, cropH),
+                            new Rect(0, 0, cropW / renderScale, cropH / renderScale));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                NLog.LogManager.GetCurrentClassLogger().Error(ex, "FrameRenderer.Render error");
+            }
+        }
+    }
+}

--- a/CollimationCircles/Views/StreamView.axaml
+++ b/CollimationCircles/Views/StreamView.axaml
@@ -8,14 +8,27 @@
 		d:DesignHeight="240"
 		xmlns:vlc="clr-namespace:LibVLCSharp.Avalonia;assembly=LibVLCSharp.Avalonia"
 		xmlns:vm="using:CollimationCircles.ViewModels"
+		xmlns:local="clr-namespace:CollimationCircles.Views"
 		x:DataType="vm:CollimationAnalysisViewModel"
 		x:Class="CollimationCircles.Views.StreamView"
 		Title="{DynamicResource Text.CameraStreamWindowTitle}"
 		Width="640"
 		Height="480">
-	<Grid>
-		<vlc:VideoView x:Name="VideoViewer">
+	<Grid x:Name="RootGrid"
+		  HorizontalAlignment="Stretch"
+		  VerticalAlignment="Stretch">
+		<vlc:VideoView x:Name="VideoViewer"
+					   HorizontalAlignment="Stretch"
+					   VerticalAlignment="Stretch"
+					   IsVisible="False">
 			<controls:CollimationAnalysisUserControl />
 		</vlc:VideoView>
+		<Grid x:Name="FrameGrid"
+			  HorizontalAlignment="Stretch"
+			  VerticalAlignment="Stretch"
+			  Background="Black"
+			  IsVisible="False">
+			<local:FrameRenderer x:Name="FrameRenderer" />
+		</Grid>
 	</Grid>
 </Window>

--- a/CollimationCircles/Views/StreamView.axaml.cs
+++ b/CollimationCircles/Views/StreamView.axaml.cs
@@ -16,12 +16,17 @@ namespace CollimationCircles.Views
         private const double MaxZoom = 4.0;
         private const double ZoomStep = 0.2;
 
-        private readonly VideoView videoViewer;
+        private readonly VideoView? videoViewer;
+        private readonly Grid? frameGrid;
+        private readonly FrameRenderer? frameRenderer;
         private readonly SettingsViewModel svm;
         private double currentZoom = 1.0;
         private int sourceVideoWidth;
         private int sourceVideoHeight;
         private bool sourceDimensionsCaptured = false;
+
+        private IZwoFrameSource? _zwoFrameSource;
+        private bool _usingZwoDirect;
 
         public StreamView()
         {
@@ -30,10 +35,11 @@ namespace CollimationCircles.Views
             DataContext = Ioc.Default.GetRequiredService<CollimationAnalysisViewModel>();
 
             videoViewer = this.Get<VideoView>("VideoViewer");
+            frameGrid = this.Get<Grid>("FrameGrid");
+            frameRenderer = this.Get<FrameRenderer>("FrameRenderer");
 
             WeakReferenceMessenger.Default.Register<SettingsChangedMessage>(this, (r, m) =>
             {
-                // FIXME: here is probably some room for optimization
                 UpdateWindowPosition();
             });
 
@@ -49,29 +55,65 @@ namespace CollimationCircles.Views
         private void StreamView_Closed(object? sender, EventArgs e)
         {
             WeakReferenceMessenger.Default.UnregisterAll(this);
+
+            if (_zwoFrameSource is not null)
+            {
+                _zwoFrameSource.FrameReady -= OnZwoFrameReady;
+                _zwoFrameSource = null;
+            }
+
+            if (frameGrid is not null)
+                frameGrid.SizeChanged -= OnFrameGridSizeChanged;
         }
 
         private void WebCamStreamWindow_Opened(object? sender, System.EventArgs e)
         {
-            var mp = Ioc.Default.GetRequiredService<ILibVLCService>().MediaPlayer;
+            _zwoFrameSource = Ioc.Default.GetRequiredService<IZwoFrameSource>();
+            _usingZwoDirect = _zwoFrameSource.IsStreaming;
 
-            if (videoViewer != null)
+            if (_usingZwoDirect)
             {
-                if (mp is not null)
+                // ZWO direct-rendering path: show FrameRenderer, hide VideoView.
+                if (videoViewer is not null) videoViewer.IsVisible = false;
+                if (frameGrid is not null) frameGrid.IsVisible = true;
+
+                sourceVideoWidth = _zwoFrameSource.FrameWidth;
+                sourceVideoHeight = _zwoFrameSource.FrameHeight;
+                sourceDimensionsCaptured = sourceVideoWidth > 0 && sourceVideoHeight > 0;
+
+                _zwoFrameSource.FrameReady += OnZwoFrameReady;
+
+                if (frameGrid is not null)
+                    frameGrid.SizeChanged += OnFrameGridSizeChanged;
+
+                currentZoom = 1.0;
+                UpdateWindowPosition();
+            }
+            else
+            {
+                // LibVLC path: show VideoView, hide FrameRenderer.
+                if (videoViewer is not null) videoViewer.IsVisible = true;
+                if (frameGrid is not null) frameGrid.IsVisible = false;
+
+                var mp = Ioc.Default.GetRequiredService<ILibVLCService>().MediaPlayer;
+
+                if (videoViewer != null && mp is not null)
                 {
                     videoViewer.MediaPlayer = mp;
-                    
-                    // Capture source dimensions once when stream starts playing
+
                     mp.Playing += (s, ev) =>
                     {
-                        if (!sourceDimensionsCaptured)
+                        if (!sourceDimensionsCaptured && TryGetVideoSize(mp, out int w, out int h))
                         {
-                            if (TryGetVideoSize(mp, out int w, out int h))
-                            {
-                                sourceVideoWidth = w;
-                                sourceVideoHeight = h;
-                                sourceDimensionsCaptured = true;
-                            }
+                            sourceVideoWidth = w;
+                            sourceVideoHeight = h;
+                            sourceDimensionsCaptured = true;
+                        }
+
+                        if (currentZoom <= 1.0)
+                        {
+                            mp.CropGeometry = string.Empty;
+                            mp.Scale = 0;
                         }
                     };
                 }
@@ -83,6 +125,16 @@ namespace CollimationCircles.Views
                 UpdateImageTransform();
                 UpdateWindowPosition();
             }
+        }
+
+        private void OnFrameGridSizeChanged(object? sender, SizeChangedEventArgs e)
+        {
+            frameRenderer?.InvalidateVisual();
+        }
+
+        private void OnZwoFrameReady(byte[] frame, int width, int height)
+        {
+            frameRenderer?.SetJpegFrame(frame);
         }
 
         private void ApplyZoom(ImageZoomAction action)
@@ -105,14 +157,17 @@ namespace CollimationCircles.Views
 
         private void UpdateImageTransform()
         {
-            var mp = videoViewer.MediaPlayer;
-
-            if (mp is null)
+            if (_usingZwoDirect)
             {
+                if (frameRenderer is not null)
+                    frameRenderer.Zoom = currentZoom;
                 return;
             }
 
-            // Use LibVLC crop geometry because native video surfaces may ignore Avalonia RenderTransform.
+            var mp = videoViewer?.MediaPlayer;
+            if (mp is null)
+                return;
+
             if (currentZoom <= 1.0)
             {
                 mp.CropGeometry = string.Empty;
@@ -120,39 +175,30 @@ namespace CollimationCircles.Views
                 return;
             }
 
-            // Try to capture source dimensions on first zoom if not yet captured
             if (!sourceDimensionsCaptured && (sourceVideoWidth <= 0 || sourceVideoHeight <= 0))
             {
                 TryGetVideoSize(mp, out sourceVideoWidth, out sourceVideoHeight);
-                sourceDimensionsCaptured = true;  // Mark as attempted even if TryGetVideoSize fails
+                sourceDimensionsCaptured = true;
             }
 
-            // If we still don't have source dimensions, can't apply zoom
             if (sourceVideoWidth <= 0 || sourceVideoHeight <= 0)
-            {
                 return;
-            }
 
-            int sourceWidth = sourceVideoWidth;
-            int sourceHeight = sourceVideoHeight;
+            int cropWidth = Math.Clamp((int)Math.Round(sourceVideoWidth / currentZoom), 1, sourceVideoWidth);
+            int cropHeight = Math.Clamp((int)Math.Round(sourceVideoHeight / currentZoom), 1, sourceVideoHeight);
 
-            int cropWidth = Math.Clamp((int)Math.Round(sourceWidth / currentZoom), 1, sourceWidth);
-            int cropHeight = Math.Clamp((int)Math.Round(sourceHeight / currentZoom), 1, sourceHeight);
-
-            double centerX = sourceWidth / 2.0;
-            double centerY = sourceHeight / 2.0;
-
+            double centerX = sourceVideoWidth / 2.0;
+            double centerY = sourceVideoHeight / 2.0;
             double halfCropWidth = cropWidth / 2.0;
             double halfCropHeight = cropHeight / 2.0;
 
-            centerX = Math.Clamp(centerX, halfCropWidth, sourceWidth - halfCropWidth);
-            centerY = Math.Clamp(centerY, halfCropHeight, sourceHeight - halfCropHeight);
+            centerX = Math.Clamp(centerX, halfCropWidth, sourceVideoWidth - halfCropWidth);
+            centerY = Math.Clamp(centerY, halfCropHeight, sourceVideoHeight - halfCropHeight);
 
-            int cropX = Math.Clamp((int)Math.Round(centerX - halfCropWidth), 0, sourceWidth - cropWidth);
-            int cropY = Math.Clamp((int)Math.Round(centerY - halfCropHeight), 0, sourceHeight - cropHeight);
+            int cropX = Math.Clamp((int)Math.Round(centerX - halfCropWidth), 0, sourceVideoWidth - cropWidth);
+            int cropY = Math.Clamp((int)Math.Round(centerY - halfCropHeight), 0, sourceVideoHeight - cropHeight);
 
-            string crop = $"{cropWidth}x{cropHeight}+{cropX}+{cropY}";
-            mp.CropGeometry = crop;
+            mp.CropGeometry = $"{cropWidth}x{cropHeight}+{cropX}+{cropY}";
             mp.Scale = 0;
         }
 
@@ -170,14 +216,10 @@ namespace CollimationCircles.Views
             uint rawHeight = 0;
 
             if (!mediaPlayer.Size(0, ref rawWidth, ref rawHeight))
-            {
                 return false;
-            }
 
             if (rawWidth == 0 || rawHeight == 0)
-            {
                 return false;
-            }
 
             width = (int)rawWidth;
             height = (int)rawHeight;


### PR DESCRIPTION
(cherry picked from commit 241f249d322acf4854698f35ffa1c4f360a77712)