### PR TITLE
fix(camera-controls): drive IsPlaying from CameraStateMessage so controls panel shows(=> collimation-helper)

### DIFF
--- a/CollimationCircles/ViewModels/CameraControlsViewModel.cs
+++ b/CollimationCircles/ViewModels/CameraControlsViewModel.cs
@@ -37,16 +37,15 @@ namespace CollimationCircles.ViewModels
             {
                 Camera = streamViewModel.SelectedCamera;
                 IsLibCamera = Camera.APIType == APIType.LibCamera;
+
+                // Drive IsPlaying from the camera state message. The MediaPlayer is
+                // lazily initialised (null at construction time), so subscribing to its
+                // events directly in the constructor never works. The messenger is the
+                // same source StreamViewModel uses to track play state.
+                IsPlaying = m.Value == CameraState.Playing;
             });
 
             Title = $"{ResSvc.TryGetString("CollimationCircles")} - {ResSvc.TryGetString("CameraControls")}";
-
-            if (libVLCService.MediaPlayer is not null)
-            {
-                libVLCService.MediaPlayer.Playing += (sender, e) => IsPlaying = true;
-                libVLCService.MediaPlayer.Paused += (sender, e) => IsPlaying = false;
-                libVLCService.MediaPlayer.Stopped += (sender, e) => IsPlaying = false;
-            }
         }
 
         [RelayCommand]


### PR DESCRIPTION
The DynamicCameraControlsUserControl (gain/exposure sliders) is bound to IsVisible={Binding IsPlaying}, but CameraControlsViewModel subscribed to MediaPlayer events directly in its constructor. MediaPlayer is lazily initialised (null at construction), so the handlers were never attached and IsPlaying stayed false forever — the controls never appeared.

Use the already-received CameraStateMessage to set IsPlaying, mirroring StreamViewModel's approach.

**Fixed:**

<img width="262" height="344" alt="image" src="https://github.com/user-attachments/assets/0205da58-58dc-4739-8311-344dade3d86c" />
