### PR TITLE
fix: center-based digital zoom for LibVLC cameras on macOS (=>collimation-helper)

### DIFF
--- a/CollimationCircles/Views/StreamView.axaml
+++ b/CollimationCircles/Views/StreamView.axaml
@@ -13,7 +13,7 @@
 		Title="{DynamicResource Text.CameraStreamWindowTitle}"
 		Width="640"
 		Height="480">
-	<Grid>
+	<Grid ClipToBounds="True">
 		<vlc:VideoView x:Name="VideoViewer">
 			<controls:CollimationAnalysisUserControl />
 		</vlc:VideoView>

--- a/CollimationCircles/Views/StreamView.axaml.cs
+++ b/CollimationCircles/Views/StreamView.axaml.cs
@@ -12,6 +12,8 @@ namespace CollimationCircles.Views
 {
     public partial class StreamView : Window
     {
+        private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
         private const double MinZoom = 0.5;
         private const double MaxZoom = 4.0;
         private const double ZoomStep = 0.2;
@@ -22,6 +24,7 @@ namespace CollimationCircles.Views
         private int sourceVideoWidth;
         private int sourceVideoHeight;
         private bool sourceDimensionsCaptured = false;
+        private bool vlcCropCleared = false;
 
         public StreamView()
         {
@@ -60,8 +63,13 @@ namespace CollimationCircles.Views
                 if (mp is not null)
                 {
                     videoViewer.MediaPlayer = mp;
-                    
-                    // Capture source dimensions once when stream starts playing
+
+                    logger.Info($"StreamView opened. MediaPlayer IsPlaying={mp.IsPlaying}, CropGeometry='{mp.CropGeometry}', Scale={mp.Scale}");
+
+                    // Capture source dimensions once when stream starts playing.
+                    // We retry on every Playing event until we get non-zero values,
+                    // because mp.Size(0,...) can return 0,0 before the first decoded
+                    // frame is available.
                     mp.Playing += (s, ev) =>
                     {
                         if (!sourceDimensionsCaptured)
@@ -71,6 +79,11 @@ namespace CollimationCircles.Views
                                 sourceVideoWidth = w;
                                 sourceVideoHeight = h;
                                 sourceDimensionsCaptured = true;
+                                logger.Info($"Captured source video dimensions from Playing event: {w}x{h}");
+                            }
+                            else
+                            {
+                                logger.Debug("Playing event fired but mp.Size(0) returned 0x0; will retry on next event.");
                             }
                         }
                     };
@@ -80,6 +93,7 @@ namespace CollimationCircles.Views
                 sourceVideoWidth = 0;
                 sourceVideoHeight = 0;
                 sourceDimensionsCaptured = false;
+                vlcCropCleared = false;
                 UpdateImageTransform();
                 UpdateWindowPosition();
             }
@@ -87,6 +101,8 @@ namespace CollimationCircles.Views
 
         private void ApplyZoom(ImageZoomAction action)
         {
+            double prevZoom = currentZoom;
+
             switch (action)
             {
                 case ImageZoomAction.In:
@@ -100,6 +116,8 @@ namespace CollimationCircles.Views
                     break;
             }
 
+            logger.Info($"ApplyZoom: action={action}, zoom {prevZoom:F2} -> {currentZoom:F2}");
+
             UpdateImageTransform();
         }
 
@@ -109,51 +127,97 @@ namespace CollimationCircles.Views
 
             if (mp is null)
             {
+                logger.Warn("UpdateImageTransform: MediaPlayer is null, skipping.");
                 return;
             }
 
-            // Use LibVLC crop geometry because native video surfaces may ignore Avalonia RenderTransform.
             if (currentZoom <= 1.0)
+            {
+                // Clear LibVLC crop/scale only once when returning to zoom=1.0,
+                // to avoid triggering a vout reconfiguration (flicker) on every call.
+                if (!vlcCropCleared)
+                {
+                    mp.CropGeometry = string.Empty;
+                    mp.Scale = 0;
+                    vlcCropCleared = true;
+                }
+
+                // Reset VideoView to fill the window
+                videoViewer.Width = double.NaN;
+                videoViewer.Height = double.NaN;
+                videoViewer.HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch;
+                videoViewer.VerticalAlignment = Avalonia.Layout.VerticalAlignment.Stretch;
+
+                logger.Info($"UpdateImageTransform: zoom<=1, reset VideoView to stretch (zoom={currentZoom:F2}).");
+                return;
+            }
+
+            // NOTE: On macOS VLC 3.0.x, CropGeometry "+X+Y" offset is ignored
+            // (crops from 0,0 → diagonal drift), Scale re-fits instead of clipping,
+            // and Avalonia RenderTransform has no effect on the native overlay.
+            //
+            // WORKAROUND: Resize the VideoView itself to be larger than the window
+            // and keep it centered.  The parent Grid's ClipToBounds clips the
+            // overflow, so only the center region of the video is visible.
+            // This is center-based zoom by construction — no VLC crop API needed.
+            //
+            // The VideoView's native overlay (NSView) resizes with the Avalonia
+            // control, and VLC auto-fits the video into the larger VideoView, so
+            // the video scales up.  The window clips what doesn't fit.
+
+            if (!sourceDimensionsCaptured && (sourceVideoWidth <= 0 || sourceVideoHeight <= 0))
+            {
+                bool ok = TryGetVideoSize(mp, out sourceVideoWidth, out sourceVideoHeight);
+                sourceDimensionsCaptured = true;
+                logger.Info($"UpdateImageTransform: late dimension capture, TryGetVideoSize={ok}, got {sourceVideoWidth}x{sourceVideoHeight}");
+            }
+
+            // Clear any stale LibVLC crop/scale only once (not on every zoom step,
+            // to avoid triggering a vout reconfiguration that causes flicker).
+            if (!vlcCropCleared)
             {
                 mp.CropGeometry = string.Empty;
                 mp.Scale = 0;
+                vlcCropCleared = true;
+            }
+
+            // Get the current window client size (the visible area / clip rect).
+            double viewWidth = ClientSize.Width;
+            double viewHeight = ClientSize.Height;
+
+            if (viewWidth <= 0 || viewHeight <= 0)
+            {
+                logger.Warn($"UpdateImageTransform: client size is {viewWidth}x{viewHeight}, cannot apply zoom {currentZoom:F2}.");
                 return;
             }
 
-            // Try to capture source dimensions on first zoom if not yet captured
-            if (!sourceDimensionsCaptured && (sourceVideoWidth <= 0 || sourceVideoHeight <= 0))
+            // Enlarge the VideoView by the zoom factor, centered on the window.
+            // The Grid's ClipToBounds clips the excess, showing only the center.
+            double scaledWidth = viewWidth * currentZoom;
+            double scaledHeight = viewHeight * currentZoom;
+
+            videoViewer.Width = scaledWidth;
+            videoViewer.Height = scaledHeight;
+            videoViewer.HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center;
+            videoViewer.VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center;
+
+            // Compute equivalent center crop for logging.
+            if (sourceVideoWidth > 0 && sourceVideoHeight > 0)
             {
-                TryGetVideoSize(mp, out sourceVideoWidth, out sourceVideoHeight);
-                sourceDimensionsCaptured = true;  // Mark as attempted even if TryGetVideoSize fails
-            }
+                int cropWidth = Math.Clamp((int)Math.Round(sourceVideoWidth / currentZoom), 1, sourceVideoWidth);
+                int cropHeight = Math.Clamp((int)Math.Round(sourceVideoHeight / currentZoom), 1, sourceVideoHeight);
+                int cropX = (sourceVideoWidth - cropWidth) / 2;
+                int cropY = (sourceVideoHeight - cropHeight) / 2;
 
-            // If we still don't have source dimensions, can't apply zoom
-            if (sourceVideoWidth <= 0 || sourceVideoHeight <= 0)
+                logger.Info($"UpdateImageTransform: zoom={currentZoom:F2}, source={sourceVideoWidth}x{sourceVideoHeight}, " +
+                            $"view={viewWidth:F0}x{viewHeight:F0}, VideoView resized to {scaledWidth:F0}x{scaledHeight:F0} (centered, clipped), " +
+                            $"equiv. center crop={cropWidth}x{cropHeight}+{cropX}+{cropY}");
+            }
+            else
             {
-                return;
+                logger.Info($"UpdateImageTransform: zoom={currentZoom:F2}, view={viewWidth:F0}x{viewHeight:F0}, " +
+                            $"VideoView resized to {scaledWidth:F0}x{scaledHeight:F0} (centered, clipped)");
             }
-
-            int sourceWidth = sourceVideoWidth;
-            int sourceHeight = sourceVideoHeight;
-
-            int cropWidth = Math.Clamp((int)Math.Round(sourceWidth / currentZoom), 1, sourceWidth);
-            int cropHeight = Math.Clamp((int)Math.Round(sourceHeight / currentZoom), 1, sourceHeight);
-
-            double centerX = sourceWidth / 2.0;
-            double centerY = sourceHeight / 2.0;
-
-            double halfCropWidth = cropWidth / 2.0;
-            double halfCropHeight = cropHeight / 2.0;
-
-            centerX = Math.Clamp(centerX, halfCropWidth, sourceWidth - halfCropWidth);
-            centerY = Math.Clamp(centerY, halfCropHeight, sourceHeight - halfCropHeight);
-
-            int cropX = Math.Clamp((int)Math.Round(centerX - halfCropWidth), 0, sourceWidth - cropWidth);
-            int cropY = Math.Clamp((int)Math.Round(centerY - halfCropHeight), 0, sourceHeight - cropHeight);
-
-            string crop = $"{cropWidth}x{cropHeight}+{cropX}+{cropY}";
-            mp.CropGeometry = crop;
-            mp.Scale = 0;
         }
 
         private void ApplyZoomDelta(double delta)


### PR DESCRIPTION
(cherry picked from commit 593652916c27990a52e814eef769d061a2d70b8c)