### PR TITLE
libuvc support for macOS

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -102,9 +102,15 @@ jobs:
           switch ("${{ matrix.runtime }}") {
             'osx-arm64' {
               Copy-Item -Force './CollimationCircles/Libraries/ASI_linux_mac_SDK_V1.41/lib/mac_arm64/libASICamera2.dylib*' $output
+              # Copy libusb + libuvc for UVC camera control and streaming on macOS
+              Copy-Item -Force './CollimationCircles/Libraries/libusb/macos/arm64/libusb-1.0.0.dylib' $output
+              Copy-Item -Force './CollimationCircles/Libraries/libuvc/macos/arm64/libuvc.dylib' $output
             }
             'osx-x64' {
               Copy-Item -Force './CollimationCircles/Libraries/ASI_linux_mac_SDK_V1.41/lib/mac/libASICamera2.dylib*' $output
+              # Copy libusb + libuvc for UVC camera control and streaming on macOS
+              Copy-Item -Force './CollimationCircles/Libraries/libusb/macos/x64/libusb-1.0.0.dylib' $output
+              Copy-Item -Force './CollimationCircles/Libraries/libuvc/macos/x64/libuvc.dylib' $output
             }
             'linux-x64' {
               Copy-Item -Force './CollimationCircles/Libraries/ASI_linux_mac_SDK_V1.41/lib/x64/libASICamera2.so*' $output

--- a/CollimationCircles/App.axaml.cs
+++ b/CollimationCircles/App.axaml.cs
@@ -73,6 +73,7 @@ public partial class App : Application
             .AddSingleton<ICameraControlService, CameraControlService>()
             .AddSingleton<ILibVLCService, LibVLCService>()
             .AddSingleton<IZwoFrameSource, ZwoFrameSource>()
+            .AddSingleton<IUvcFrameSource, UvcFrameSource>()
             .AddTransient<ImageViewModel>()
             .BuildServiceProvider());
     }

--- a/CollimationCircles/CollimationCircles.csproj
+++ b/CollimationCircles/CollimationCircles.csproj
@@ -129,6 +129,46 @@
     <Message Text="Copied ZWO ASI Camera SDK Windows library to $(OutputPath)" Importance="high" />
   </Target>
 
+  <!-- macOS: Copy libusb dylib for UVC camera control -->
+  <Target Name="CopyLibUsbMacArm64" AfterTargets="Build" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">
+    <ItemGroup>
+      <LibUsbFiles Include="Libraries\libusb\macos\arm64\libusb-1.0.0.dylib" />
+    </ItemGroup>
+    <Copy SourceFiles="@(LibUsbFiles)" DestinationFolder="$(OutputPath)" />
+    <Message Text="Copied libusb-1.0.0.dylib to $(OutputPath)" Importance="high" />
+  </Target>
+  <Target Name="CopyLibUsbMacX64" AfterTargets="Build" Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
+    <ItemGroup>
+      <LibUsbFiles Include="Libraries\libusb\macos\x64\libusb-1.0.0.dylib" />
+    </ItemGroup>
+    <Copy SourceFiles="@(LibUsbFiles)" DestinationFolder="$(OutputPath)" />
+    <Message Text="Copied libusb-1.0.0.dylib to $(OutputPath)" Importance="high" />
+  </Target>
+
+  <!-- macOS: Copy libuvc dylib for UVC camera control + streaming -->
+  <Target Name="CopyLibUvcMacArm64" AfterTargets="Build" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">
+    <ItemGroup>
+      <LibUvcFiles Include="Libraries\libuvc\macos\arm64\libuvc.dylib" />
+    </ItemGroup>
+    <Copy SourceFiles="@(LibUvcFiles)" DestinationFolder="$(OutputPath)" />
+    <Message Text="Copied libuvc.dylib to $(OutputPath)" Importance="high" />
+  </Target>
+  <Target Name="CopyLibUvcMacX64" AfterTargets="Build" Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
+    <ItemGroup>
+      <LibUvcFiles Include="Libraries\libuvc\macos\x64\libuvc.dylib" />
+    </ItemGroup>
+    <Copy SourceFiles="@(LibUvcFiles)" DestinationFolder="$(OutputPath)" />
+    <Message Text="Copied libuvc.dylib to $(OutputPath)" Importance="high" />
+  </Target>
+
+  <!-- macOS: Ad-hoc code-sign the copied dylibs so the app doesn't get SIGKILL'd
+       by the kernel (macOS requires a valid signature for loaded dylibs). -->
+  <Target Name="CodesignDylibsMac" AfterTargets="CopyLibUvcMac" Condition="'$(RuntimeIdentifier)' == 'osx-arm64' Or '$(RuntimeIdentifier)' == 'osx-x64'">
+    <Exec Command="codesign --force --sign - &quot;$(OutputPath)libusb-1.0.0.dylib&quot;" />
+    <Exec Command="codesign --force --sign - &quot;$(OutputPath)libuvc.dylib&quot;" />
+    <Message Text="Ad-hoc signed libusb and libuvc dylibs" Importance="high" />
+  </Target>
+
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <Content Include="Libraries\libvlc\**\*.*">
       <Link>libvlc\%(RecursiveDir)%(Filename)%(Extension)</Link>

--- a/CollimationCircles/Models/APIType.cs
+++ b/CollimationCircles/Models/APIType.cs
@@ -7,6 +7,7 @@
         Dshow,
         QTCapture,
         Zwo,
+        Uvc,
         Remote
     }
 }

--- a/CollimationCircles/Models/Camera.cs
+++ b/CollimationCircles/Models/Camera.cs
@@ -10,6 +10,8 @@ namespace CollimationCircles.Models
         public string Name { get; set; } = string.Empty;
         public APIType APIType { get; set; }
         public string Path { get; set; } = string.Empty;
+        public int VendorId { get; set; }
+        public int ProductId { get; set; }
 
         [ObservableProperty]
         public List<ICameraControl> controls = [];

--- a/CollimationCircles/Models/CameraControl.cs
+++ b/CollimationCircles/Models/CameraControl.cs
@@ -6,7 +6,9 @@ namespace CollimationCircles.Models
 {
     public partial class CameraControl(ControlType controlName, Camera camera) : ObservableObject, ICameraControl
     {
+        private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
         private readonly ICameraControlService cameraControlService = Ioc.Default.GetRequiredService<ICameraControlService>();
+        private bool suppressCameraDispatch;
         public ControlType Name { get; set; } = controlName;
         public int Min { get; set; }
         public int Max { get; set; }
@@ -26,19 +28,70 @@ namespace CollimationCircles.Models
 
         private readonly Camera _camera = camera;
 
+        internal void ApplyDiscoveredState(int min, int max, double step, int @default, int currentValue, bool autoSupported, bool currentAuto, string flags, ControlValueType valueType)
+        {
+            suppressCameraDispatch = true;
+            try
+            {
+                Min = min;
+                Max = max;
+                Step = step;
+                Default = @default;
+                AutoSupported = autoSupported;
+                Flags = flags;
+                ValueType = valueType;
+                Value = currentValue;
+                IsAuto = currentAuto;
+
+                OnPropertyChanged(nameof(Min));
+                OnPropertyChanged(nameof(Max));
+                OnPropertyChanged(nameof(Step));
+                OnPropertyChanged(nameof(Default));
+                OnPropertyChanged(nameof(AutoSupported));
+                OnPropertyChanged(nameof(Flags));
+                OnPropertyChanged(nameof(ValueType));
+            }
+            finally
+            {
+                suppressCameraDispatch = false;
+            }
+        }
+
         partial void OnValueChanged(int oldValue, int newValue)
         {
+            if (suppressCameraDispatch)
+            {
+                return;
+            }
+
+            logger.Info($"UI control change: camera='{_camera?.Name}', control={Name}, oldValue={oldValue}, newValue={newValue}, isPlaying={_camera?.IsPlaying}");
+
             if (_camera is not null && _camera.IsPlaying)
             {
                 cameraControlService.Set(Name, newValue, _camera);
+            }
+            else
+            {
+                logger.Warn($"Ignoring UI control change because camera is not playing: camera='{_camera?.Name}', control={Name}, attemptedValue={newValue}");
             }
         }
 
         partial void OnIsAutoChanged(bool oldValue, bool newValue)
         {
+            if (suppressCameraDispatch)
+            {
+                return;
+            }
+
+            logger.Info($"UI auto-control change: camera='{_camera?.Name}', control={Name}, oldValue={oldValue}, newValue={newValue}, autoSupported={AutoSupported}, isPlaying={_camera?.IsPlaying}");
+
             if (_camera is not null && AutoSupported)
             {
                 cameraControlService.SetAuto(Name, newValue, _camera);
+            }
+            else
+            {
+                logger.Warn($"Ignoring UI auto-control change: camera='{_camera?.Name}', control={Name}, autoSupported={AutoSupported}, isPlaying={_camera?.IsPlaying}");
             }
         }
 

--- a/CollimationCircles/Models/ICamera.cs
+++ b/CollimationCircles/Models/ICamera.cs
@@ -8,6 +8,8 @@ namespace CollimationCircles.Models
         public string Name { get; set; }
         public APIType APIType { get; set; }
         public string Path { get; set; }
+        public int VendorId { get; set; }
+        public int ProductId { get; set; }
         public List<ICameraControl> Controls { get; set; }
         public bool IsPlaying { get; set; }
         public void SetDefaultControls();

--- a/CollimationCircles/Program.cs
+++ b/CollimationCircles/Program.cs
@@ -47,6 +47,15 @@ namespace CollimationCircles
 
             try
             {
+                if (StartupOptions.RecoverUvcVidPid is { } recoverVidPid)
+                {
+                    bool recovered = UvcFrameSource.TryRecoverUvcDevice(recoverVidPid.VendorId, recoverVidPid.ProductId);
+                    logger.Info(recovered
+                        ? $"UVC recovery mode completed for {recoverVidPid.VendorId}:{recoverVidPid.ProductId}."
+                        : $"UVC recovery mode failed for {recoverVidPid.VendorId}:{recoverVidPid.ProductId}.");
+                    return;
+                }
+
                 BootstrapMacArm64VlcEnvironment(args);
                 ConfigureLinuxEnvironment();
 

--- a/CollimationCircles/Services/CameraControlService.cs
+++ b/CollimationCircles/Services/CameraControlService.cs
@@ -15,7 +15,7 @@ namespace CollimationCircles.Services
             Guard.IsNotNull(camera);
             Guard.IsTrue(camera.IsPlaying);
 
-            logger.Info($"Setting update requested: camera='{camera.Name}', api={camera.APIType}, control={controlName}, value={value}");
+            logger.Info($"Dispatching camera control set: camera='{camera.Name}', api={camera.APIType}, control={controlName}, value={value}");
 
             // set camera control for V4L2 (Linux cameras)
             if (camera.APIType is APIType.V4l2)
@@ -27,7 +27,12 @@ namespace CollimationCircles.Services
             {
                 new ZWOCameraDetect().SetControl(camera, controlName, value);
             }
-            // set camera control for macOS system cameras
+            // set camera control for macOS UVC cameras (IOKit + libusb)
+            else if (camera.APIType is APIType.Uvc)
+            {
+                new MacOSCameraDetect().SetControl(camera, controlName, value);
+            }
+            // set camera control for macOS system cameras (AVFoundation/QTCapture fallback)
             else if (camera.APIType is APIType.QTCapture)
             {
                 new MacOSCameraDetect().SetControl(camera, controlName, value);
@@ -48,13 +53,13 @@ namespace CollimationCircles.Services
         {
             Guard.IsNotNull(camera);
 
-            logger.Info($"Auto-setting update requested: camera='{camera.Name}', api={camera.APIType}, control={controlName}, isAuto={isAuto}");
+            logger.Info($"Dispatching camera auto-control set: camera='{camera.Name}', api={camera.APIType}, control={controlName}, isAuto={isAuto}, isPlaying={camera.IsPlaying}");
 
             if (camera.APIType is APIType.Zwo)
             {
                 new ZWOCameraDetect().SetControlAuto(camera, controlName, isAuto);
             }
-            else if (camera.APIType is APIType.QTCapture)
+            else if (camera.APIType is APIType.Uvc)
             {
                 new MacOSCameraDetect().SetControlAuto(camera, controlName, isAuto);
             }

--- a/CollimationCircles/Services/IUvcFrameSource.cs
+++ b/CollimationCircles/Services/IUvcFrameSource.cs
@@ -1,0 +1,45 @@
+using CollimationCircles.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CollimationCircles.Services
+{
+    /// <summary>
+    /// Provides direct frame delivery from a UVC camera via libusb, bypassing LibVLC.
+    /// The <see cref="FrameReady"/> event fires for every captured frame with
+    /// JPEG-encoded image data.
+    /// </summary>
+    internal interface IUvcFrameSource
+    {
+        /// <summary>True while a UVC camera stream is active.</summary>
+        bool IsStreaming { get; }
+
+        /// <summary>Width of the captured frame in pixels (0 until stream starts).</summary>
+        int FrameWidth { get; }
+
+        /// <summary>Height of the captured frame in pixels (0 until stream starts).</summary>
+        int FrameHeight { get; }
+
+        /// <summary>
+        /// Fired on the capture thread for every new frame. The byte array
+        /// contains JPEG-encoded image data of size <see cref="FrameWidth"/> × <see cref="FrameHeight"/>.
+        /// </summary>
+        event Action<byte[], int, int>? FrameReady;
+
+        /// <summary>Opens the UVC camera and starts the capture loop.</summary>
+        Task<bool> StartAsync(Camera camera);
+
+        /// <summary>Stops the capture loop and closes the camera.</summary>
+        void Stop();
+
+        /// <summary>Sets a UVC control value on the active stream.</summary>
+        bool SetControl(string controlName, long value);
+
+        /// <summary>Sets a UVC auto control value on the active stream.</summary>
+        bool SetAutoControl(string controlName, bool isAuto);
+
+        /// <summary>Enumerates all supported UVC controls (requires device to be open).</summary>
+        List<ICameraControl> EnumerateControls(Camera camera);
+    }
+}

--- a/CollimationCircles/Services/IokitHelper.cs
+++ b/CollimationCircles/Services/IokitHelper.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace CollimationCircles.Services
+{
+    /// <summary>
+    /// Minimal IOKit P/Invoke helper for detaching the macOS kernel UVC driver.
+    ///
+    /// On macOS, the kernel UVC driver (AppleUSBHostUVCDriver / AppleUserUVC)
+    /// claims the camera's USB interfaces, which prevents libusb (and therefore
+    /// libuvc) from accessing them. IOKit's SetConfiguration(0) detaches the
+    /// kernel driver WITHOUT root privileges. After reconfiguring, libuvc races
+    /// to claim the interface before the kernel driver re-attaches.
+    ///
+    /// This is the only piece that libuvc cannot do on its own on macOS —
+    /// libuvc's libusb_detach_kernel_driver is not sufficient because the
+    /// kernel driver is not a "module" that libusb can detach; it's an IOKit
+    /// service that needs to be unconfigured at the device level.
+    /// </summary>
+    internal static class IokitHelper
+    {
+        private const string IOKitFramework = "/System/Library/Frameworks/IOKit.framework/IOKit";
+        private const string CoreFoundation = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+
+        private const uint kCFStringEncodingUTF8 = 0x08000100;
+
+        // IOKit UUIDs for USB device interface (from IOUSBLib.h and IOCFPlugIn.h)
+        public static readonly Guid kIOUSBDeviceUserClientTypeID = new("9dc7b780-9ec0-11d4-a54f-000a27052861");
+        public static readonly Guid kIOCFPlugInInterfaceID = new("c244e858-109c-11d4-91d4-0050e4c6426f");
+        public static readonly Guid kIOUSBDeviceInterfaceID = new("5c8187d0-9ef3-11d4-8b45-000a27052861");
+
+        // IOKit USB constants
+        private const string kIOUSBDeviceClassName = "IOUSBDevice";
+        private const string kUSBVendorID = "idVendor";
+        private const string kUSBProductID = "idProduct";
+
+        // -------------------------------------------------------------------
+        // P/Invoke declarations
+        // -------------------------------------------------------------------
+
+        [DllImport(IOKitFramework)]
+        private static extern IntPtr IOServiceMatching(string name);
+
+        [DllImport(IOKitFramework)]
+        private static extern int IOServiceGetMatchingServices(IntPtr mainPort, IntPtr matchingDict, out int iter);
+
+        [DllImport(IOKitFramework)]
+        private static extern int IOIteratorNext(int iter);
+
+        [DllImport(IOKitFramework)]
+        private static extern int IOObjectRelease(int obj);
+
+        [DllImport(IOKitFramework)]
+        private static extern int IOCreatePlugInInterfaceForService(
+            int service, IntPtr typeID, IntPtr interfaceID,
+            out IntPtr plugInInterface, out int score);
+
+        [DllImport(IOKitFramework)]
+        private static extern int IODestroyPlugInInterface(IntPtr interfaceRef);
+
+        [DllImport(CoreFoundation)]
+        private static extern IntPtr CFNumberCreate(IntPtr alloc, int theType, ref int value);
+
+        [DllImport(CoreFoundation)]
+        private static extern void CFDictionarySetValue(IntPtr dict, IntPtr key, IntPtr value);
+
+        [DllImport(CoreFoundation)]
+        private static extern void CFRelease(IntPtr cf);
+
+        [DllImport(CoreFoundation)]
+        private static extern IntPtr CFUUIDCreateFromUUIDBytes(IntPtr alloc, CFUUIDBytes uuidBytes);
+
+        // -------------------------------------------------------------------
+        // CFUUID / Guid byte-order conversion
+        // -------------------------------------------------------------------
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct CFUUIDBytes
+        {
+            public byte byte0; public byte byte1; public byte byte2; public byte byte3;
+            public byte byte4; public byte byte5; public byte byte6; public byte byte7;
+            public byte byte8; public byte byte9; public byte byte10; public byte byte11;
+            public byte byte12; public byte byte13; public byte byte14; public byte byte15;
+        }
+
+        private static CFUUIDBytes CreateCFUUIDBytes(Guid guid)
+        {
+            byte[] g = guid.ToByteArray();
+            byte[] cf = new byte[16];
+            cf[0] = g[3]; cf[1] = g[2]; cf[2] = g[1]; cf[3] = g[0];
+            cf[4] = g[5]; cf[5] = g[4];
+            cf[6] = g[7]; cf[7] = g[6];
+            Array.Copy(g, 8, cf, 8, 8);
+            return new CFUUIDBytes
+            {
+                byte0 = cf[0], byte1 = cf[1], byte2 = cf[2], byte3 = cf[3],
+                byte4 = cf[4], byte5 = cf[5], byte6 = cf[6], byte7 = cf[7],
+                byte8 = cf[8], byte9 = cf[9], byte10 = cf[10], byte11 = cf[11],
+                byte12 = cf[12], byte13 = cf[13], byte14 = cf[14], byte15 = cf[15],
+            };
+        }
+
+        private static IntPtr CreateCFUUIDRef(Guid guid)
+        {
+            return CFUUIDCreateFromUUIDBytes(IntPtr.Zero, CreateCFUUIDBytes(guid));
+        }
+
+        // -------------------------------------------------------------------
+        // CFString helper
+        // -------------------------------------------------------------------
+
+        [DllImport(CoreFoundation, EntryPoint = "CFStringCreateWithCString")]
+        private static extern IntPtr CFStringCreateWithCString(IntPtr alloc, string cStr, uint encoding);
+
+        private static IntPtr CreateCFString(string s) => CFStringCreateWithCString(IntPtr.Zero, s, kCFStringEncodingUTF8);
+
+        // -------------------------------------------------------------------
+        // IOKit C COM interface delegates
+        // -------------------------------------------------------------------
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int QueryInterfaceDelegate(IntPtr self, CFUUIDBytes iid, out IntPtr result);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate uint ReleaseDelegate(IntPtr self);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int UsbDeviceOpenDelegate(IntPtr self);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int UsbDeviceCloseDelegate(IntPtr self);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int SetConfigurationDelegate(IntPtr self, byte configuration);
+
+        // -------------------------------------------------------------------
+        // Core: SetConfiguration
+        // -------------------------------------------------------------------
+
+        /// <summary>
+        /// Uses IOKit to open the USB device and set its configuration.
+        /// SetConfiguration(0) detaches the kernel UVC driver (no root needed).
+        /// SetConfiguration(1) re-attaches it (restores normal camera operation).
+        /// Returns the configuration value that was active before, or 0 on failure.
+        /// </summary>
+        public static int SetConfiguration(int vendorId, int productId, int targetConfig)
+        {
+            try
+            {
+                IntPtr matchingDict = IOServiceMatching(kIOUSBDeviceClassName);
+                if (matchingDict == IntPtr.Zero) return 0;
+
+                int vid = vendorId, pid = productId;
+                IntPtr vidRef = CFNumberCreate(IntPtr.Zero, 3, ref vid);
+                IntPtr pidRef = CFNumberCreate(IntPtr.Zero, 3, ref pid);
+                IntPtr vendorKey = CreateCFString(kUSBVendorID);
+                IntPtr productKey = CreateCFString(kUSBProductID);
+
+                CFDictionarySetValue(matchingDict, vendorKey, vidRef);
+                CFDictionarySetValue(matchingDict, productKey, pidRef);
+
+                CFRelease(vidRef);
+                CFRelease(pidRef);
+                if (vendorKey != IntPtr.Zero) CFRelease(vendorKey);
+                if (productKey != IntPtr.Zero) CFRelease(productKey);
+
+                int kr = IOServiceGetMatchingServices(IntPtr.Zero, matchingDict, out int iter);
+                if (kr != 0) return 0;
+
+                int usbDevice = IOIteratorNext(iter);
+                IOObjectRelease(iter);
+                if (usbDevice == 0) return 0;
+
+                IntPtr typeIDRef = CreateCFUUIDRef(kIOUSBDeviceUserClientTypeID);
+                IntPtr ifaceIDRef = CreateCFUUIDRef(kIOCFPlugInInterfaceID);
+
+                kr = IOCreatePlugInInterfaceForService(usbDevice, typeIDRef, ifaceIDRef,
+                    out IntPtr plugInInterface, out int score);
+
+                if (typeIDRef != IntPtr.Zero) CFRelease(typeIDRef);
+                if (ifaceIDRef != IntPtr.Zero) CFRelease(ifaceIDRef);
+
+                if (kr != 0 || plugInInterface == IntPtr.Zero)
+                {
+                    IOObjectRelease(usbDevice);
+                    return 0;
+                }
+
+                IntPtr devInterface = QueryInterfaceForUsbDevice(plugInInterface);
+                IODestroyPlugInInterface(plugInInterface);
+                IOObjectRelease(usbDevice);
+
+                if (devInterface == IntPtr.Zero) return 0;
+
+                int result = UsbDeviceOpenSetConfig(devInterface, targetConfig);
+                ReleaseUsbDeviceInterface(devInterface);
+                return result;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        private static IntPtr QueryInterfaceForUsbDevice(IntPtr plugInInterface)
+        {
+            IntPtr ifacePtr = Marshal.ReadIntPtr(plugInInterface);
+            if (ifacePtr == IntPtr.Zero) return IntPtr.Zero;
+
+            IntPtr queryInterfacePtr = Marshal.ReadIntPtr(ifacePtr, IntPtr.Size * 1);
+            if (queryInterfacePtr == IntPtr.Zero) return IntPtr.Zero;
+
+            CFUUIDBytes iid = CreateCFUUIDBytes(kIOUSBDeviceInterfaceID);
+            var queryInterface = Marshal.GetDelegateForFunctionPointer<QueryInterfaceDelegate>(queryInterfacePtr);
+            int hr = queryInterface(plugInInterface, iid, out IntPtr result);
+            return hr != 0 ? IntPtr.Zero : result;
+        }
+
+        private static void ReleaseUsbDeviceInterface(IntPtr devInterface)
+        {
+            if (devInterface == IntPtr.Zero) return;
+            IntPtr ifacePtr = Marshal.ReadIntPtr(devInterface);
+            if (ifacePtr == IntPtr.Zero) return;
+            IntPtr releasePtr = Marshal.ReadIntPtr(ifacePtr, IntPtr.Size * 3);
+            if (releasePtr == IntPtr.Zero) return;
+            var release = Marshal.GetDelegateForFunctionPointer<ReleaseDelegate>(releasePtr);
+            _ = release(devInterface);
+        }
+
+        private static int UsbDeviceOpenSetConfig(IntPtr devInterface, int targetConfig)
+        {
+            IntPtr ifacePtr = Marshal.ReadIntPtr(devInterface);
+            if (ifacePtr == IntPtr.Zero) return 0;
+
+            // USBDeviceOpen (index 8)
+            IntPtr openPtr = Marshal.ReadIntPtr(ifacePtr, IntPtr.Size * 8);
+            var open = Marshal.GetDelegateForFunctionPointer<UsbDeviceOpenDelegate>(openPtr);
+            int kr = open(devInterface);
+            if (kr != 0) return 0;
+
+            int result = 0;
+
+            // SetConfiguration (index 23)
+            IntPtr setConfigPtr = Marshal.ReadIntPtr(ifacePtr, IntPtr.Size * 23);
+            var setConfig = Marshal.GetDelegateForFunctionPointer<SetConfigurationDelegate>(setConfigPtr);
+            kr = setConfig(devInterface, (byte)targetConfig);
+
+            // USBDeviceClose (index 9)
+            IntPtr closePtr = Marshal.ReadIntPtr(ifacePtr, IntPtr.Size * 9);
+            var close = Marshal.GetDelegateForFunctionPointer<UsbDeviceCloseDelegate>(closePtr);
+            close(devInterface);
+
+            // SetConfiguration(0) detaches the driver; return 1 as "active config was 1"
+            // SetConfiguration(N) re-attaches; return N
+            result = targetConfig == 0 ? 1 : targetConfig;
+            return result;
+        }
+
+        /// <summary>
+        /// Restores the kernel driver by setting configuration back to 1.
+        /// Call this after uvc_close to give the camera back to macOS.
+        /// </summary>
+        public static void RestoreKernelDriver(int vendorId, int productId)
+        {
+            if (vendorId <= 0 || productId <= 0) return;
+            try
+            {
+                SetConfiguration(vendorId, productId, 1);
+            }
+            catch { }
+        }
+    }
+}

--- a/CollimationCircles/Services/LibUvcInterop.cs
+++ b/CollimationCircles/Services/LibUvcInterop.cs
@@ -1,0 +1,426 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace CollimationCircles.Services
+{
+    /// <summary>
+    /// P/Invoke bindings for libuvc (https://github.com/libuvc/libuvc).
+    ///
+    /// libuvc is a cross-platform C library that provides full UVC camera access:
+    ///   - Kernel driver detachment (libusb_detach_kernel_driver on macOS)
+    ///   - UVC descriptor parsing (formats, frames, intervals)
+    ///   - Probe/commit negotiation
+    ///   - Isochronous &amp; bulk streaming with multiple queued transfer buffers
+    ///   - Frame assembly (FID/EOF, MJPEG/YUYV/etc.)
+    ///   - All UVC processing-unit and camera-terminal controls
+    ///
+    /// This replaces the custom IOKit + raw libusb implementation with a tested
+    /// library that is already used by astronomy software (oaCapture, etc.) on macOS.
+    /// </summary>
+    internal static class LibUvc
+    {
+        private const string LibName = "libuvc";
+
+        // -------------------------------------------------------------------
+        // Error codes (enum uvc_error)
+        // -------------------------------------------------------------------
+
+        public const int UVC_SUCCESS = 0;
+        public const int UVC_ERROR_IO = -1;
+        public const int UVC_ERROR_INVALID_PARAM = -2;
+        public const int UVC_ERROR_ACCESS = -3;
+        public const int UVC_ERROR_NO_DEVICE = -4;
+        public const int UVC_ERROR_NOT_FOUND = -5;
+        public const int UVC_ERROR_BUSY = -6;
+        public const int UVC_ERROR_TIMEOUT = -7;
+        public const int UVC_ERROR_OVERFLOW = -8;
+        public const int UVC_ERROR_PIPE = -9;
+        public const int UVC_ERROR_INTERRUPTED = -10;
+        public const int UVC_ERROR_NO_MEM = -11;
+        public const int UVC_ERROR_NOT_SUPPORTED = -12;
+        public const int UVC_ERROR_INVALID_DEVICE = -50;
+        public const int UVC_ERROR_INVALID_MODE = -51;
+
+        // -------------------------------------------------------------------
+        // Frame formats (enum uvc_frame_format)
+        // -------------------------------------------------------------------
+
+        public const int UVC_FRAME_FORMAT_UNKNOWN = 0;
+        public const int UVC_FRAME_FORMAT_ANY = 0;
+        public const int UVC_FRAME_FORMAT_UNCOMPRESSED = 1;
+        public const int UVC_FRAME_FORMAT_COMPRESSED = 2;
+        public const int UVC_FRAME_FORMAT_YUYV = 3;
+        public const int UVC_FRAME_FORMAT_UYVY = 4;
+        public const int UVC_FRAME_FORMAT_RGB = 5;
+        public const int UVC_FRAME_FORMAT_BGR = 6;
+        public const int UVC_FRAME_FORMAT_MJPEG = 7;
+        public const int UVC_FRAME_FORMAT_H264 = 8;
+        public const int UVC_FRAME_FORMAT_GRAY8 = 9;
+        public const int UVC_FRAME_FORMAT_GRAY16 = 10;
+
+        // -------------------------------------------------------------------
+        // Request codes (enum uvc_req_code)
+        // -------------------------------------------------------------------
+
+        public const byte UVC_SET_CUR = 0x01;
+        public const byte UVC_GET_CUR = 0x81;
+        public const byte UVC_GET_MIN = 0x82;
+        public const byte UVC_GET_MAX = 0x83;
+        public const byte UVC_GET_RES = 0x84;
+        public const byte UVC_GET_LEN = 0x85;
+        public const byte UVC_GET_INFO = 0x86;
+        public const byte UVC_GET_DEF = 0x87;
+
+        // -------------------------------------------------------------------
+        // VS descriptor subtypes (enum uvc_vs_desc_subtype)
+        // -------------------------------------------------------------------
+
+        public const int UVC_VS_FORMAT_UNCOMPRESSED = 0x04;
+        public const int UVC_VS_FRAME_UNCOMPRESSED = 0x05;
+        public const int UVC_VS_FORMAT_MJPEG = 0x06;
+        public const int UVC_VS_FRAME_MJPEG = 0x07;
+
+        // -------------------------------------------------------------------
+        // Structures
+        // -------------------------------------------------------------------
+
+        /// <summary>
+        /// uvc_stream_ctrl_t — 34 bytes matching the UVC probe/commit structure.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct uvc_stream_ctrl_t
+        {
+            public ushort bmHint;
+            public byte bFormatIndex;
+            public byte bFrameIndex;
+            public uint dwFrameInterval;
+            public ushort wKeyFrameRate;
+            public ushort wPFrameRate;
+            public ushort wCompQuality;
+            public ushort wCompWindowSize;
+            public ushort wDelay;
+            public uint dwMaxVideoFrameSize;
+            public uint dwMaxPayloadTransferSize;
+            public uint dwClockFrequency;
+            public byte bmFramingInfo;
+            public byte bPreferredVersion;
+            public byte bMinVersion;
+            public byte bMaxVersion;
+            public byte bInterfaceNumber;
+        }
+
+        /// <summary>
+        /// uvc_frame_t — the frame delivered to the callback.
+        /// We only need the first few fields; the rest are accessed via Marshal.
+        /// Layout: data(ptr) data_bytes(size) width(uint32) height(uint32) frame_format(int) ...
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct uvc_frame_t
+        {
+            public IntPtr data;            // void *data
+            public nuint data_bytes;       // size_t data_bytes
+            public uint width;             // uint32_t width
+            public uint height;            // uint32_t height
+            public int frame_format;       // enum uvc_frame_format
+            public nuint step;             // size_t step
+            public uint sequence;          // uint32_t sequence
+            // capture_time (struct timeval) and remaining fields follow
+            // but we don't need them — we read data/data_bytes/width/height only.
+        }
+
+        // The linked-list structs use prev/next pointers (utlist DL_FOREACH).
+        // We access fields by offset via Marshal instead of full structs.
+
+        // uvc_format_desc_t layout (after IUNKNOWN-style headers in the linked list):
+        //   parent(ptr)  prev(ptr)  next(ptr)
+        //   bDescriptorSubtype(enum=int)  bFormatIndex(byte)  bNumFrameDescriptors(byte)
+        //   guidFormat[16] / fourccFormat[4] (union, 16 bytes)
+        //   bBitsPerPixel / bmFlags (union, 1 byte)
+        //   bDefaultFrameIndex(byte)
+        //   ... more fields
+        // We read bFormatIndex and fourccFormat by offset.
+
+        // uvc_frame_desc_t layout:
+        //   parent(ptr)  prev(ptr)  next(ptr)
+        //   bDescriptorSubtype(enum=int)  bFrameIndex(byte)  bmCapabilities(byte)
+        //   wWidth(ushort)  wHeight(ushort)
+        //   dwMinBitRate(uint)  dwMaxBitRate(uint)
+        //   dwMaxVideoFrameBufferSize(uint)  dwDefaultFrameInterval(uint)
+        //   ... more fields
+        // We read wWidth, wHeight, bFrameIndex by offset.
+
+        // uvc_processing_unit_t layout:
+        //   prev(ptr)  next(ptr)  bUnitID(byte)  bSourceID(byte)  bmControls(uint64)
+        // We read bUnitID and bmControls by offset.
+
+        // uvc_input_terminal_t layout:
+        //   prev(ptr)  next(ptr)  bTerminalID(byte)  wTerminalType(enum=int)
+        //   wObjectiveFocalLengthMin(ushort)  wObjectiveFocalLengthMax(ushort)
+        //   wOcularFocalLength(ushort)  bmControls(uint64)
+        // We read bTerminalID and bmControls by offset.
+
+        // -------------------------------------------------------------------
+        // Callback delegate
+        // -------------------------------------------------------------------
+
+        /// <summary>
+        /// uvc_frame_callback_t: void callback(uvc_frame_t *frame, void *user_ptr)
+        /// Called by libuvc on the streaming thread when a complete frame is ready.
+        /// WARNING: Must not call any uvc_* functions from within the callback.
+        /// </summary>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void uvc_frame_callback_t(IntPtr frame, IntPtr user_ptr);
+
+        // -------------------------------------------------------------------
+        // Core API
+        // -------------------------------------------------------------------
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_init(out IntPtr ctx, IntPtr usb_ctx);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void uvc_exit(IntPtr ctx);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_find_device(IntPtr ctx, out IntPtr dev, int vid, int pid,
+            [MarshalAs(UnmanagedType.LPStr)] string? sn);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_open(IntPtr dev, out IntPtr devh);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void uvc_close(IntPtr devh);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void uvc_unref_device(IntPtr dev);
+
+        // -------------------------------------------------------------------
+        // Device descriptor
+        // -------------------------------------------------------------------
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_device_descriptor(IntPtr dev, out IntPtr desc);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void uvc_free_device_descriptor(IntPtr desc);
+
+        // uvc_device_descriptor_t: idVendor(ushort) idProduct(ushort) bcdUVC(ushort)
+        //   serialNumber(ptr) manufacturer(ptr) product(ptr)
+        [StructLayout(LayoutKind.Sequential)]
+        public struct uvc_device_descriptor_t
+        {
+            public ushort idVendor;
+            public ushort idProduct;
+            public ushort bcdUVC;
+            public IntPtr serialNumber;
+            public IntPtr manufacturer;
+            public IntPtr product;
+        }
+
+        // -------------------------------------------------------------------
+        // Format / frame descriptor enumeration
+        // -------------------------------------------------------------------
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr uvc_get_format_descs(IntPtr devh);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr uvc_get_processing_units(IntPtr devh);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr uvc_get_camera_terminal(IntPtr devh);
+
+        // -------------------------------------------------------------------
+        // Stream control
+        // -------------------------------------------------------------------
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_stream_ctrl_format_size(
+            IntPtr devh, ref uvc_stream_ctrl_t ctrl,
+            int format, int width, int height, int fps);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_probe_stream_ctrl(IntPtr devh, ref uvc_stream_ctrl_t ctrl);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_start_streaming(
+            IntPtr devh, ref uvc_stream_ctrl_t ctrl,
+            uvc_frame_callback_t cb, IntPtr user_ptr, byte flags);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void uvc_stop_streaming(IntPtr devh);
+
+        // -------------------------------------------------------------------
+        // Frame allocation
+        // -------------------------------------------------------------------
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr uvc_allocate_frame(nuint data_bytes);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void uvc_free_frame(IntPtr frame);
+
+        // -------------------------------------------------------------------
+        // Generic control get/set (for arbitrary unit/selector)
+        // -------------------------------------------------------------------
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_ctrl(IntPtr devh, byte unit, byte ctrl,
+            byte[] data, int len, byte req_code);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_ctrl(IntPtr devh, byte unit, byte ctrl,
+            byte[] data, int len);
+
+        // -------------------------------------------------------------------
+        // Typed control getters/setters
+        // -------------------------------------------------------------------
+
+        // Brightness (int16, signed)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_brightness(IntPtr devh, out short val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_brightness(IntPtr devh, short val);
+
+        // Contrast (uint16)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_contrast(IntPtr devh, out ushort val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_contrast(IntPtr devh, ushort val);
+
+        // Contrast auto (uint8)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_contrast_auto(IntPtr devh, out byte val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_contrast_auto(IntPtr devh, byte val);
+
+        // Gain (uint16)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_gain(IntPtr devh, out ushort val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_gain(IntPtr devh, ushort val);
+
+        // Hue (int16, signed)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_hue(IntPtr devh, out short val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_hue(IntPtr devh, short val);
+
+        // Hue auto (uint8)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_hue_auto(IntPtr devh, out byte val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_hue_auto(IntPtr devh, byte val);
+
+        // Saturation (uint16)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_saturation(IntPtr devh, out ushort val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_saturation(IntPtr devh, ushort val);
+
+        // Sharpness (uint16)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_sharpness(IntPtr devh, out ushort val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_sharpness(IntPtr devh, ushort val);
+
+        // Gamma (uint16)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_gamma(IntPtr devh, out ushort val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_gamma(IntPtr devh, ushort val);
+
+        // White balance temperature (uint16)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_white_balance_temperature(IntPtr devh, out ushort val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_white_balance_temperature(IntPtr devh, ushort val);
+
+        // White balance temperature auto (uint8)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_white_balance_temperature_auto(IntPtr devh, out byte val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_white_balance_temperature_auto(IntPtr devh, byte val);
+
+        // Backlight compensation (uint16)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_backlight_compensation(IntPtr devh, out ushort val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_backlight_compensation(IntPtr devh, ushort val);
+
+        // Power line frequency (uint8)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_power_line_frequency(IntPtr devh, out byte val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_power_line_frequency(IntPtr devh, byte val);
+
+        // AE mode (uint8)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_ae_mode(IntPtr devh, out byte val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_ae_mode(IntPtr devh, byte val);
+
+        // Exposure absolute (uint32)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_exposure_abs(IntPtr devh, out uint val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_exposure_abs(IntPtr devh, uint val);
+
+        // Focus absolute (uint16)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_focus_abs(IntPtr devh, out ushort val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_focus_abs(IntPtr devh, ushort val);
+
+        // Focus auto (uint8)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_focus_auto(IntPtr devh, out byte val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_focus_auto(IntPtr devh, byte val);
+
+        // Zoom absolute (uint16)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_zoom_abs(IntPtr devh, out ushort val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_zoom_abs(IntPtr devh, ushort val);
+
+        // Iris absolute (uint16)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_iris_abs(IntPtr devh, out ushort val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_iris_abs(IntPtr devh, ushort val);
+
+        // Roll absolute (int16, signed)
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_get_roll_abs(IntPtr devh, out short val, byte req);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uvc_set_roll_abs(IntPtr devh, short val);
+
+        // -------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------
+
+        public static string ErrorName(int error)
+        {
+            return error switch
+            {
+                UVC_SUCCESS => "SUCCESS",
+                UVC_ERROR_IO => "ERROR_IO",
+                UVC_ERROR_INVALID_PARAM => "ERROR_INVALID_PARAM",
+                UVC_ERROR_ACCESS => "ERROR_ACCESS",
+                UVC_ERROR_NO_DEVICE => "ERROR_NO_DEVICE",
+                UVC_ERROR_NOT_FOUND => "ERROR_NOT_FOUND",
+                UVC_ERROR_BUSY => "ERROR_BUSY",
+                UVC_ERROR_TIMEOUT => "ERROR_TIMEOUT",
+                UVC_ERROR_OVERFLOW => "ERROR_OVERFLOW",
+                UVC_ERROR_PIPE => "ERROR_PIPE",
+                UVC_ERROR_INTERRUPTED => "ERROR_INTERRUPTED",
+                UVC_ERROR_NO_MEM => "ERROR_NO_MEM",
+                UVC_ERROR_NOT_SUPPORTED => "ERROR_NOT_SUPPORTED",
+                UVC_ERROR_INVALID_DEVICE => "ERROR_INVALID_DEVICE",
+                UVC_ERROR_INVALID_MODE => "ERROR_INVALID_MODE",
+                _ => $"UNKNOWN({error})"
+            };
+        }
+    }
+}

--- a/CollimationCircles/Services/LibVLCService.cs
+++ b/CollimationCircles/Services/LibVLCService.cs
@@ -405,6 +405,30 @@ namespace CollimationCircles.Services
                 return;
             }
 
+            if (camera.APIType == APIType.Uvc)
+            {
+                // UVC cameras on macOS bypass LibVLC entirely — frames are rendered
+                // directly by FrameRenderer via IUvcFrameSource (IOKit + libusb).
+                logger.Info($"Starting UVC direct stream for camera '{camera.Name}' (VID={camera.VendorId} PID={camera.ProductId})");
+                var uvcFrameSource = Ioc.Default.GetRequiredService<IUvcFrameSource>();
+
+                bool started = await uvcFrameSource.StartAsync(camera);
+
+                if (!started)
+                {
+                    logger.Error($"Failed to start UVC direct stream for camera '{camera.Name}'");
+                    SendCameraStateOnUIThread(CameraState.Stopped);
+                    return;
+                }
+
+                FullAddress = $"uvc-direct://{camera.VendorId}:{camera.ProductId}";
+                logger.Info($"UVC direct stream started for camera '{camera.Name}' ({uvcFrameSource.FrameWidth}×{uvcFrameSource.FrameHeight})");
+
+                SendCameraStateOnUIThread(CameraState.Opening);
+                SendCameraStateOnUIThread(CameraState.Playing);
+                return;
+            }
+
             if (!EnsureInitialized() || libVLC is null || MediaPlayer is null)
             {
                 logger.Warn("Ignoring Play request because LibVLC is not available on this platform/runtime.");
@@ -502,6 +526,12 @@ namespace CollimationCircles.Services
                 protocol = "http";
                 address = "localhost";
                 port = "8091";
+            }
+            else if (camera.APIType == APIType.Uvc)
+            {
+                // UVC cameras use direct rendering, not a URL-based stream.
+                protocol = "uvc-direct";
+                address = $"{camera.VendorId}:{camera.ProductId}";
             }
 
             string newRemoteAddress = address;

--- a/CollimationCircles/Services/MacOSCameraDetect.cs
+++ b/CollimationCircles/Services/MacOSCameraDetect.cs
@@ -1,10 +1,13 @@
 using CollimationCircles.Models;
 using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace CollimationCircles.Services
@@ -12,6 +15,13 @@ namespace CollimationCircles.Services
     internal class MacOSCameraDetect : ICameraDetect
     {
         private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+        public Dictionary<ControlType, object> ControlMapping => new()
+        {
+            { ControlType.ExposureTime, "ExposureTime" },
+            { ControlType.FocusAbsolute, "FocusAbsolute" },
+            { ControlType.WhiteBalance, "WhiteBalance" }
+        };
 
         private sealed class AvFoundationControlDto
         {
@@ -30,13 +40,6 @@ namespace CollimationCircles.Services
             public List<AvFoundationControlDto> Controls { get; set; } = [];
         }
 
-        public Dictionary<ControlType, object> ControlMapping => new()
-        {
-            { ControlType.ExposureTime, "ExposureTime" },
-            { ControlType.FocusAbsolute, "FocusAbsolute" },
-            { ControlType.WhiteBalance, "WhiteBalance" }
-        };
-
         public async Task<List<Camera>> GetCameras()
         {
             List<Camera> cameras = [];
@@ -46,7 +49,9 @@ namespace CollimationCircles.Services
                 return cameras;
             }
 
+            // First, try to get cameras from system_profiler (built-in cameras)
             await DetectSystemProfilerCameras(cameras);
+
             return cameras;
         }
 
@@ -101,20 +106,95 @@ namespace CollimationCircles.Services
             {
                 string? name = TryGetString(cameraElement, "_name");
                 string? uniqueId = TryGetString(cameraElement, "spcamera_unique-id");
+                string? modelId = TryGetString(cameraElement, "spcamera_model-id");
 
                 if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(uniqueId))
-                {
                     continue;
+
+                // Parse vendor/product IDs from model-id string like:
+                // "UVC Camera VendorID_60324 ProductID_4867"
+                int vendorId = 0;
+                int productId = 0;
+
+                if (!string.IsNullOrWhiteSpace(modelId))
+                {
+                    _ = TryExtractVidPid(modelId, out vendorId, out productId);
                 }
+
+                // Use Uvc APIType for cameras with vendor/product IDs (real UVC cameras)
+                // Fall back to QTCapture for built-in/virtual cameras without UVC IDs
+                APIType apiType = (vendorId > 0 && productId > 0) ? APIType.Uvc : APIType.QTCapture;
 
                 yield return new Camera
                 {
                     Index = index++,
-                    APIType = APIType.QTCapture,
+                    APIType = apiType,
                     Name = name,
-                    Path = uniqueId.Trim()
+                    Path = uniqueId.Trim(),
+                    VendorId = vendorId,
+                    ProductId = productId
                 };
             }
+        }
+
+        private static bool TryExtractVidPid(string source, out int vendorId, out int productId)
+        {
+            vendorId = 0;
+            productId = 0;
+
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                return false;
+            }
+
+            // Accept several common forms returned by macOS tools, for example:
+            // VendorID_60324 ProductID_4867
+            // Vendor ID: 0xeb94 Product ID: 0x1303
+            // VID=60324 PID=4867
+            var vidMatch = Regex.Match(
+                source,
+                @"(?:Vendor\s*ID|VendorID|VID)\s*[_:=-]?\s*(0x[0-9A-Fa-f]+|\d+)",
+                RegexOptions.IgnoreCase);
+            var pidMatch = Regex.Match(
+                source,
+                @"(?:Product\s*ID|ProductID|PID)\s*[_:=-]?\s*(0x[0-9A-Fa-f]+|\d+)",
+                RegexOptions.IgnoreCase);
+
+            if (!vidMatch.Success || !pidMatch.Success)
+            {
+                return false;
+            }
+
+            if (!TryParseDeviceId(vidMatch.Groups[1].Value, out vendorId))
+            {
+                return false;
+            }
+
+            if (!TryParseDeviceId(pidMatch.Groups[1].Value, out productId))
+            {
+                return false;
+            }
+
+            return vendorId > 0 && productId > 0;
+        }
+
+        private static bool TryParseDeviceId(string value, out int id)
+        {
+            id = 0;
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            value = value.Trim();
+
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                return int.TryParse(value[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out id);
+            }
+
+            return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out id);
         }
 
         private static string? TryGetString(JsonElement element, string propertyName)
@@ -128,12 +208,140 @@ namespace CollimationCircles.Services
             return propertyElement.GetString();
         }
 
+        private async Task DetectUSBCameras(List<Camera> cameras)
+        {
+            try
+            {
+                // Try two methods: ioreg and system_profiler
+                
+                // Method 1: Try ioreg (more detailed but may require more parsing)
+                await TryDetectViaIoreg(cameras);
+                
+                // Method 2: Try system_profiler SPUSBDataType (more reliable)
+                await TryDetectViaSystemProfilerUSB(cameras);
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "Error while detecting USB cameras");
+            }
+        }
+
+        private async Task TryDetectViaIoreg(List<Camera> cameras)
+        {
+            try
+            {
+                var (errorCode, result) = await AppService.StartProcessAsync(
+                    "ioreg",
+                    ["-p", "IOUSB"]);
+
+                if (errorCode == 0)
+                {
+                    logger.Debug("ioreg output available, parsing for astro cameras");
+                    
+                    // Look for ASI cameras (ZWO)
+                    string asiPattern = @"ASI\s*([0-9]+[A-Z]*)";
+                    var matches = Regex.Matches(result, asiPattern, RegexOptions.IgnoreCase);
+
+                    int cameraIndex = 1;
+                    foreach (Match match in matches.Cast<Match>())
+                    {
+                        string name = $"ASI {match.Groups[1].Value}";
+                        
+                        if (!cameras.Any(c => c.Name == name))
+                        {
+                            Camera camera = new()
+                            {
+                                Index = cameras.Count,
+                                APIType = APIType.QTCapture,
+                                Name = name,
+                                Path = cameraIndex.ToString()
+                            };
+
+                            camera.Controls = await GetControls(camera);
+                            cameras.Add(camera);
+                            cameraIndex++;
+                            logger.Info($"Added camera via ioreg: '{camera.Name}'");
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Debug($"ioreg detection failed (non-critical): {ex.Message}");
+            }
+        }
+
+        private async Task TryDetectViaSystemProfilerUSB(List<Camera> cameras)
+        {
+            try
+            {
+                var (errorCode, result) = await AppService.StartProcessAsync(
+                    "system_profiler",
+                    ["SPUSBDataType"]);
+
+                if (errorCode == 0)
+                {
+                    logger.Debug("SPUSBDataType output available, parsing for astro cameras");
+                    
+                    // Look for common astro camera product names
+                    string[] patterns = new[]
+                    {
+                        @"Product:\s+(.+?ASI.+?)(?=\n|$)",  // ZWO ASI cameras
+                        @"Product:\s+(.+?SV.+?)(?=\n|$)",   // SVBONY cameras
+                        @"Product:\s+(.+?QHY.+?)(?=\n|$)",  // QHY cameras
+                        @"Product:\s+(.+?TouCam.+?)(?=\n|$)" // Philips TouCam
+                    };
+
+                    int cameraIndex = 1;
+                    foreach (string pattern in patterns)
+                    {
+                        var matches = Regex.Matches(result, pattern, RegexOptions.IgnoreCase);
+                        
+                        foreach (Match match in matches.Cast<Match>())
+                        {
+                            string name = match.Groups[1].Value.Trim();
+                            
+                            if (!string.IsNullOrWhiteSpace(name) && !cameras.Any(c => c.Name == name))
+                            {
+                                Camera camera = new()
+                                {
+                                    Index = cameras.Count,
+                                    APIType = APIType.QTCapture,
+                                    Name = name,
+                                    Path = cameraIndex.ToString()
+                                };
+
+                                camera.Controls = await GetControls(camera);
+                                cameras.Add(camera);
+                                cameraIndex++;
+                                logger.Info($"Added USB camera via SPUSBDataType: '{camera.Name}'");
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Debug($"SPUSBDataType detection failed (non-critical): {ex.Message}");
+            }
+        }
+
         public async Task<List<ICameraControl>> GetControls(Camera camera)
         {
             Guard.IsNotNull(camera);
 
             List<ICameraControl> controls = [];
 
+            // For UVC cameras with vendor/product IDs, controls are enumerated at
+            // stream start by UvcFrameSource.EnumerateControls (via libuvc).
+            // Return empty list here — placeholders will be replaced on Play.
+            if (camera.APIType is APIType.Uvc && camera.VendorId > 0 && camera.ProductId > 0)
+            {
+                logger.Info($"UVC camera '{camera.Name}' (VID={camera.VendorId} PID={camera.ProductId}) — controls will be enumerated on stream start");
+                return controls;
+            }
+
+            // QTCapture cameras: discover controls via AVFoundation (Swift script)
             if (!OperatingSystem.IsMacOS() || camera.APIType is not APIType.QTCapture)
             {
                 return controls;
@@ -167,7 +375,8 @@ func clamp(_ value: Double, _ minValue: Double, _ maxValue: Double) -> Double {
 let deviceId = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : """"
 let cameraName = CommandLine.arguments.count > 2 ? CommandLine.arguments[2] : """"
 
-let devices = AVCaptureDevice.devices(for: .video)
+let session = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera, .external], mediaType: .video, position: .unspecified)
+let devices = session.devices
 let device = devices.first { $0.uniqueID == deviceId }
     ?? devices.first { $0.localizedName == cameraName }
 
@@ -291,6 +500,32 @@ print(String(data: data, encoding: .utf8)!)
 
         public void SetControl(Camera camera, ControlType controlType, double value)
         {
+            // For UVC cameras, control setting is handled via UvcFrameSource
+            // which has the device open during streaming.
+            if (camera.APIType is APIType.Uvc)
+            {
+                try
+                {
+                    logger.Info($"macOS UVC set request: camera='{camera.Name}', control={controlType}, value={value}");
+                    var uvcFrameSource = Ioc.Default.GetRequiredService<IUvcFrameSource>();
+                    bool ok = uvcFrameSource.SetControl(controlType.ToString(), (long)value);
+                    if (!ok)
+                    {
+                        logger.Warn($"Failed to set UVC control {controlType}={value} on '{camera.Name}'");
+                    }
+                    else
+                    {
+                        logger.Info($"macOS UVC set request completed: camera='{camera.Name}', control={controlType}, value={value}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, $"Error setting UVC control {controlType} on '{camera.Name}'");
+                }
+                return;
+            }
+
+            // QTCapture: AVFoundation mode-only controls (numeric set is not supported)
             if (!OperatingSystem.IsMacOS() || camera.APIType is not APIType.QTCapture)
             {
                 return;
@@ -317,6 +552,49 @@ print(String(data: data, encoding: .utf8)!)
 
         public void SetControlAuto(Camera camera, ControlType controlType, bool isAuto)
         {
+            // UVC cameras: route to UvcFrameSource (libuvc)
+            if (camera.APIType is APIType.Uvc)
+            {
+                try
+                {
+                    logger.Info($"macOS UVC auto set request: camera='{camera.Name}', control={controlType}, isAuto={isAuto}");
+                    var uvcFrameSource = Ioc.Default.GetRequiredService<IUvcFrameSource>();
+
+                    string autoName = controlType switch
+                    {
+                        ControlType.ExposureTime => "AutoExposure",
+                        ControlType.FocusAbsolute => "AutoFocus",
+                        ControlType.WhiteBalance => "AutoWhiteBalance",
+                        ControlType.Hue => "HueAuto",
+                        ControlType.Contrast => "ContrastAuto",
+                        _ => string.Empty
+                    };
+
+                    if (!string.IsNullOrEmpty(autoName))
+                    {
+                        bool ok = uvcFrameSource.SetAutoControl(autoName, isAuto);
+                        if (!ok)
+                        {
+                            logger.Warn($"Failed to set UVC auto control {controlType}={isAuto} on '{camera.Name}'");
+                        }
+                        else
+                        {
+                            logger.Info($"macOS UVC auto set request completed: camera='{camera.Name}', control={controlType}, isAuto={isAuto}");
+                        }
+                    }
+                    else
+                    {
+                        logger.Warn($"No UVC auto-control mapping for {controlType} on '{camera.Name}'");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, $"Error setting UVC auto control {controlType} on '{camera.Name}'");
+                }
+                return;
+            }
+
+            // QTCapture: set auto mode via AVFoundation Swift script
             if (!OperatingSystem.IsMacOS() || camera.APIType is not APIType.QTCapture)
             {
                 return;
@@ -347,7 +625,8 @@ let cameraName = CommandLine.arguments.count > 2 ? CommandLine.arguments[2] : ""
 let control = CommandLine.arguments.count > 3 ? CommandLine.arguments[3] : """"
 let autoEnabled = CommandLine.arguments.count > 4 ? (CommandLine.arguments[4] == ""1"") : false
 
-let devices = AVCaptureDevice.devices(for: .video)
+let session = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera, .external], mediaType: .video, position: .unspecified)
+let devices = session.devices
 guard let device = devices.first(where: { $0.uniqueID == deviceId })
     ?? devices.first(where: { $0.localizedName == cameraName }) else {
     print(""device-not-found"")

--- a/CollimationCircles/Services/UvcFrameSource.cs
+++ b/CollimationCircles/Services/UvcFrameSource.cs
@@ -1,0 +1,869 @@
+using CollimationCircles.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace CollimationCircles.Services
+{
+    /// <summary>
+    /// Direct UVC camera frame source using the libuvc library
+    /// (https://github.com/libuvc/libuvc) via P/Invoke.
+    ///
+    /// libuvc handles kernel driver detachment, UVC descriptor parsing, probe/commit
+    /// negotiation, isochronous/bulk streaming with multiple queued transfer buffers,
+    /// frame assembly, and all UVC controls — all in a tested C library used by
+    /// astronomy software (oaCapture, etc.) on macOS.
+    ///
+    /// Frames are delivered via <see cref="FrameReady"/> as JPEG-encoded image data
+    /// for direct rendering by <see cref="FrameRenderer"/>.
+    /// </summary>
+    internal sealed class UvcFrameSource : IUvcFrameSource, IDisposable
+    {
+        private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+        // libuvc context and device handles
+        private IntPtr _ctx = IntPtr.Zero;
+        private IntPtr _dev = IntPtr.Zero;
+        private IntPtr _devh = IntPtr.Zero;
+
+        // Entity IDs for UVC controls
+        private byte _puId = 0;  // processing unit entity ID
+        private byte _ctId = 0;  // camera terminal entity ID
+
+        // Stream info
+        private int _width = 0;
+        private int _height = 0;
+        private volatile bool _running;
+
+        // Frame callback delegate — MUST be kept alive (stored as a field) to
+        // prevent GC collection while libuvc holds a raw function pointer to it.
+        private LibUvc.uvc_frame_callback_t? _frameCallback;
+
+        // Track whether we've logged the "non-MJPEG format" warning
+        private bool _loggedNonMjpeg;
+
+        // -------------------------------------------------------------------
+        // IUvcFrameSource interface
+        // -------------------------------------------------------------------
+
+        public bool IsStreaming => _running && _devh != IntPtr.Zero;
+        public int FrameWidth => _width;
+        public int FrameHeight => _height;
+        public event Action<byte[], int, int>? FrameReady;
+
+        public async Task<bool> StartAsync(Camera camera)
+        {
+            logger.Info($"UvcFrameSource.StartAsync: begin for '{camera.Name}' (VID={camera.VendorId} PID={camera.ProductId})");
+            Stop();
+
+            if (camera.VendorId <= 0 || camera.ProductId <= 0)
+            {
+                logger.Error($"Cannot start UVC stream: vendor/product IDs not available for '{camera.Name}'");
+                return false;
+            }
+
+            bool opened = await Task.Run(() => OpenDevice(camera.VendorId, camera.ProductId));
+            if (!opened)
+            {
+                logger.Error($"Failed to open UVC device for '{camera.Name}' (VID={camera.VendorId} PID={camera.ProductId})");
+                return false;
+            }
+
+            // Discover entity IDs for control routing
+            DiscoverEntityIds();
+            logger.Info($"UvcFrameSource.StartAsync: PU ID={_puId}, CT ID={_ctId}");
+
+            // Enumerate real UVC controls and update the camera's control list
+            try
+            {
+                var realControls = EnumerateControls(camera);
+                if (realControls.Count > 0)
+                {
+                    camera.Controls = realControls;
+                    logger.Info($"Updated camera '{camera.Name}' with {realControls.Count} real UVC controls");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Warn(ex, $"Failed to enumerate UVC controls for '{camera.Name}' — keeping placeholder controls");
+            }
+
+            // Start streaming
+            bool started;
+            try
+            {
+                started = StartStreaming(camera);
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, $"Unhandled exception while starting UVC stream for '{camera.Name}'");
+                started = false;
+            }
+
+            if (!started)
+            {
+                logger.Error($"Failed to start UVC streaming for '{camera.Name}'");
+                CloseDevice();
+                return false;
+            }
+
+            logger.Info($"UVC stream started for '{camera.Name}' ({_width}×{_height})");
+            return true;
+        }
+
+        public void Stop()
+        {
+            if (!_running && _devh == IntPtr.Zero) return;
+
+            _running = false;
+
+            if (_devh != IntPtr.Zero)
+            {
+                try
+                {
+                    LibUvc.uvc_stop_streaming(_devh);
+                }
+                catch (Exception ex)
+                {
+                    logger.Warn(ex, "uvc_stop_streaming threw exception");
+                }
+            }
+
+            CloseDevice();
+            logger.Info("UVC stream stopped");
+        }
+
+        // -------------------------------------------------------------------
+        // Device open / close
+        // -------------------------------------------------------------------
+
+        // Last VID/PID for kernel driver restore on close
+        private int _lastVendorId = 0;
+        private int _lastProductId = 0;
+        private int _restoreConfig = 1;
+
+        private bool OpenDevice(int vendorId, int productId)
+        {
+            logger.Debug($"OpenDevice: begin VID={vendorId} PID={productId}");
+            _lastVendorId = vendorId;
+            _lastProductId = productId;
+
+            // Step 1: IOKit SetConfiguration(0) to detach the macOS kernel UVC driver.
+            // libuvc's libusb_detach_kernel_driver is NOT sufficient on macOS —
+            // the kernel driver is an IOKit service, not a libusb module.
+            // SetConfiguration(0) unconfigures the device at the IOKit level,
+            // which releases the kernel driver from all interfaces.
+            logger.Debug("OpenDevice: step 1 — IOKit SetConfiguration(0) to detach kernel driver");
+            int targetConfig = IokitHelper.SetConfiguration(vendorId, productId, 0);
+            logger.Debug($"OpenDevice: IokitSetConfiguration(0) returned targetConfig={targetConfig}");
+            if (targetConfig == 0)
+            {
+                logger.Error("IOKit SetConfiguration(0) failed — cannot detach kernel driver");
+                return false;
+            }
+            _restoreConfig = targetConfig;
+
+            // Brief wait for kernel driver to release interfaces before the retry loop
+            System.Threading.Thread.Sleep(100);
+
+            // Step 2: libuvc init + find + open with retry loop.
+            // On macOS there's a race condition: after IOKit SetConfiguration(0)
+            // detaches the kernel driver, the driver can re-attach before
+            // libuvc claims the interface. We retry the IOKit detach + uvc_open
+            // sequence up to 20 times (matching the old code's strategy).
+            int ret = LibUvc.uvc_init(out _ctx, IntPtr.Zero);
+            if (ret != LibUvc.UVC_SUCCESS)
+            {
+                logger.Error($"uvc_init failed: {LibUvc.ErrorName(ret)}");
+                IokitHelper.RestoreKernelDriver(vendorId, productId);
+                return false;
+            }
+            logger.Debug($"OpenDevice: uvc_init success, ctx={_ctx}");
+
+            bool opened = false;
+            for (int attempt = 0; attempt < 20; attempt++)
+            {
+                // Re-detach kernel driver on each attempt (the driver may have re-attached)
+                if (attempt > 0)
+                {
+                    logger.Debug($"OpenDevice: attempt {attempt} — re-detaching kernel driver via IOKit SetConfiguration(0)");
+                    IokitHelper.SetConfiguration(vendorId, productId, 0);
+                    System.Threading.Thread.Sleep(50);
+                }
+
+                // Re-find the device (the libusb device list may change after reconfig)
+                ret = LibUvc.uvc_find_device(_ctx, out _dev, vendorId, productId, null);
+                if (ret != LibUvc.UVC_SUCCESS)
+                {
+                    logger.Debug($"OpenDevice: uvc_find_device attempt {attempt} failed: {LibUvc.ErrorName(ret)}");
+                    continue;
+                }
+
+                ret = LibUvc.uvc_open(_dev, out _devh);
+                if (ret == LibUvc.UVC_SUCCESS)
+                {
+                    logger.Info($"uvc_open: SUCCESS on attempt {attempt} — device handle={_devh}");
+                    opened = true;
+                    break;
+                }
+
+                logger.Debug($"OpenDevice: uvc_open attempt {attempt} failed: {LibUvc.ErrorName(ret)}");
+                LibUvc.uvc_unref_device(_dev);
+                _dev = IntPtr.Zero;
+                System.Threading.Thread.Sleep(50);
+            }
+
+            if (!opened)
+            {
+                logger.Error($"uvc_open failed after 20 attempts: {LibUvc.ErrorName(ret)}");
+                LibUvc.uvc_exit(_ctx);
+                _ctx = IntPtr.Zero;
+                IokitHelper.RestoreKernelDriver(vendorId, productId);
+                return false;
+            }
+
+            return true;
+        }
+
+        private void CloseDevice()
+        {
+            if (_devh != IntPtr.Zero)
+            {
+                LibUvc.uvc_close(_devh);
+                _devh = IntPtr.Zero;
+            }
+
+            if (_dev != IntPtr.Zero)
+            {
+                LibUvc.uvc_unref_device(_dev);
+                _dev = IntPtr.Zero;
+            }
+
+            if (_ctx != IntPtr.Zero)
+            {
+                LibUvc.uvc_exit(_ctx);
+                _ctx = IntPtr.Zero;
+            }
+
+            // Restore the kernel driver so the camera works normally again
+            // (e.g. in AVFoundation / FaceTime / other apps)
+            if (_lastVendorId > 0 && _lastProductId > 0)
+            {
+                IokitHelper.RestoreKernelDriver(_lastVendorId, _lastProductId);
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // Entity ID discovery
+        // -------------------------------------------------------------------
+
+        private void DiscoverEntityIds()
+        {
+            // Processing unit
+            IntPtr pu = LibUvc.uvc_get_processing_units(_devh);
+            if (pu != IntPtr.Zero)
+            {
+                // uvc_processing_unit_t: prev(ptr) next(ptr) bUnitID(byte) bSourceID(byte) bmControls(uint64)
+                int offsetUnitId = IntPtr.Size * 2; // after prev + next
+                _puId = Marshal.ReadByte(pu, offsetUnitId);
+                logger.Info($"Processing unit ID: {_puId}");
+            }
+            else
+            {
+                _puId = 1;
+                logger.Warn("No processing unit found — using fallback ID 1");
+            }
+
+            // Camera terminal (input terminal)
+            IntPtr ct = LibUvc.uvc_get_camera_terminal(_devh);
+            if (ct != IntPtr.Zero)
+            {
+                // uvc_input_terminal_t: prev(ptr) next(ptr) bTerminalID(byte) wTerminalType(enum=int) ...
+                int offsetTermId = IntPtr.Size * 2; // after prev + next
+                _ctId = Marshal.ReadByte(ct, offsetTermId);
+                logger.Info($"Camera terminal ID: {_ctId}");
+            }
+            else
+            {
+                _ctId = 1;
+                logger.Warn("No camera terminal found — using fallback ID 1");
+            }
+
+            if (_puId == _ctId)
+            {
+                logger.Warn($"DiscoverEntityIds: PU and CT share entity ID {_puId}. Camera-terminal controls will be unreliable on this device.");
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // Control enumeration
+        // -------------------------------------------------------------------
+
+        private record ControlDef(string Name, byte Selector, int DataLen, bool IsSigned, string? AutoName);
+        private record AutoControlDef(string Name, byte Selector);
+
+        // UVC processing unit control selectors
+        private const byte UVC_PU_BRIGHTNESS = 0x02;
+        private const byte UVC_PU_CONTRAST = 0x03;
+        private const byte UVC_PU_GAIN = 0x04;
+        private const byte UVC_PU_POWER_LINE_FREQUENCY = 0x05;
+        private const byte UVC_PU_HUE = 0x06;
+        private const byte UVC_PU_SATURATION = 0x07;
+        private const byte UVC_PU_SHARPNESS = 0x08;
+        private const byte UVC_PU_GAMMA = 0x09;
+        private const byte UVC_PU_WHITE_BALANCE_TEMP = 0x0a;
+        private const byte UVC_PU_WHITE_BALANCE_TEMP_AUTO = 0x0b;
+        private const byte UVC_PU_HUE_AUTO = 0x10;
+        private const byte UVC_PU_CONTRAST_AUTO = 0x13;
+        private const byte UVC_PU_BACKLIGHT_COMPENSATION = 0x01;
+
+        // UVC camera terminal control selectors
+        private const byte UVC_CT_AE_MODE = 0x02;
+        private const byte UVC_CT_EXPOSURE_TIME_ABS = 0x04;
+        private const byte UVC_CT_FOCUS_ABS = 0x06;
+        private const byte UVC_CT_FOCUS_AUTO = 0x08;
+        private const byte UVC_CT_ZOOM_ABS = 0x0b;
+        private const byte UVC_CT_IRIS_ABS = 0x09;
+        private const byte UVC_CT_ROLL_ABS = 0x0f;
+
+        private static readonly ControlDef[] PuControls =
+        [
+            new("Brightness",           UVC_PU_BRIGHTNESS,             2, true,  null),
+            new("Contrast",             UVC_PU_CONTRAST,               2, false, "ContrastAuto"),
+            new("Gain",                 UVC_PU_GAIN,                   2, false, null),
+            new("Hue",                  UVC_PU_HUE,                    2, true,  "HueAuto"),
+            new("Saturation",           UVC_PU_SATURATION,             2, false, null),
+            new("Sharpness",            UVC_PU_SHARPNESS,              2, false, null),
+            new("Gamma",                UVC_PU_GAMMA,                  2, false, null),
+            new("WhiteBalance",         UVC_PU_WHITE_BALANCE_TEMP,     2, false, "AutoWhiteBalance"),
+            new("BacklightCompensation",UVC_PU_BACKLIGHT_COMPENSATION, 2, false, null),
+            new("PowerLineFrequency",   UVC_PU_POWER_LINE_FREQUENCY,   1, false, null),
+        ];
+
+        private static readonly ControlDef[] CtControls =
+        [
+            new("ExposureTime",     UVC_CT_EXPOSURE_TIME_ABS, 4, false, "AutoExposure"),
+            new("FocusAbsolute",    UVC_CT_FOCUS_ABS,         2, false, "AutoFocus"),
+            new("Zoom_Absolute",    UVC_CT_ZOOM_ABS,          2, false, null),
+            new("Iris",             UVC_CT_IRIS_ABS,          2, false, null),
+            new("Roll",             UVC_CT_ROLL_ABS,          2, true,  null),
+        ];
+
+        private static readonly AutoControlDef[] AutoControls =
+        [
+            new("AutoExposure",        UVC_CT_AE_MODE),
+            new("AutoFocus",           UVC_CT_FOCUS_AUTO),
+            new("AutoWhiteBalance",    UVC_PU_WHITE_BALANCE_TEMP_AUTO),
+            new("HueAuto",             UVC_PU_HUE_AUTO),
+            new("ContrastAuto",        UVC_PU_CONTRAST_AUTO),
+        ];
+
+        public List<ICameraControl> EnumerateControls(Camera camera)
+        {
+            List<ICameraControl> controls = [];
+            bool preferCameraTerminalAliases = _puId == _ctId
+                && camera.VendorId == 60324 && camera.ProductId == 4867;
+
+            // Processing unit controls
+            foreach (var c in PuControls)
+            {
+                if (!ControlSupported(_puId, c.Selector)) continue;
+
+                long mn = ReadCtrlGeneric(_puId, c.Selector, c.DataLen, c.IsSigned, LibUvc.UVC_GET_MIN);
+                long mx = ReadCtrlGeneric(_puId, c.Selector, c.DataLen, c.IsSigned, LibUvc.UVC_GET_MAX);
+                long st = ReadCtrlGeneric(_puId, c.Selector, c.DataLen, c.IsSigned, LibUvc.UVC_GET_RES);
+                long df = ReadCtrlGeneric(_puId, c.Selector, c.DataLen, c.IsSigned, LibUvc.UVC_GET_DEF);
+                long cv = ReadCtrlGeneric(_puId, c.Selector, c.DataLen, c.IsSigned, LibUvc.UVC_GET_CUR);
+
+                (bool autoSup, bool isAuto) = CheckAuto(c.AutoName);
+
+                if (Enum.TryParse(c.Name, out ControlType ct))
+                {
+                    var control = new CameraControl(ct, camera);
+                    control.ApplyDiscoveredState((int)mn, (int)mx, st, (int)df, (int)cv, autoSup, isAuto, "rw", ControlValueType.Int);
+                    controls.Add(control);
+                    logger.Info($"UVC control '{c.Name}' min={mn} max={mx} step={st} default={df} value={cv} auto={autoSup} for '{camera.Name}'");
+                }
+
+                if (preferCameraTerminalAliases)
+                {
+                    string aliasName = c.Selector switch
+                    {
+                        UVC_PU_GAIN => "ExposureTime",
+                        UVC_PU_HUE => "FocusAbsolute",
+                        _ => c.Name
+                    };
+                    if (aliasName != c.Name && Enum.TryParse(aliasName, out ControlType aliasType))
+                    {
+                        var aliasControl = new CameraControl(aliasType, camera);
+                        aliasControl.ApplyDiscoveredState((int)mn, (int)mx, st, (int)df, (int)cv, false, false, "rw", ControlValueType.Int);
+                        controls.Add(aliasControl);
+                        logger.Info($"UVC aliased control '{aliasName}' for '{camera.Name}' (shared selector=0x{c.Selector:X2})");
+                    }
+                }
+            }
+
+            // Camera terminal controls (skip if PU and CT share entity ID)
+            if (_ctId == _puId)
+            {
+                if (!preferCameraTerminalAliases)
+                {
+                    logger.Warn($"Skipping camera-terminal control enumeration because PU and CT share entity ID {_ctId}.");
+                }
+                return controls;
+            }
+
+            foreach (var c in CtControls)
+            {
+                if (!ControlSupported(_ctId, c.Selector)) continue;
+
+                long mn = ReadCtrlGeneric(_ctId, c.Selector, c.DataLen, c.IsSigned, LibUvc.UVC_GET_MIN);
+                long mx = ReadCtrlGeneric(_ctId, c.Selector, c.DataLen, c.IsSigned, LibUvc.UVC_GET_MAX);
+                long st = ReadCtrlGeneric(_ctId, c.Selector, c.DataLen, c.IsSigned, LibUvc.UVC_GET_RES);
+                long df = ReadCtrlGeneric(_ctId, c.Selector, c.DataLen, c.IsSigned, LibUvc.UVC_GET_DEF);
+                long cv = ReadCtrlGeneric(_ctId, c.Selector, c.DataLen, c.IsSigned, LibUvc.UVC_GET_CUR);
+
+                (bool autoSup, bool isAuto) = CheckAuto(c.AutoName);
+
+                if (Enum.TryParse(c.Name, out ControlType ct))
+                {
+                    var control = new CameraControl(ct, camera);
+                    control.ApplyDiscoveredState((int)mn, (int)mx, st, (int)df, (int)cv, autoSup, isAuto, "rw", ControlValueType.Int);
+                    controls.Add(control);
+                    logger.Info($"UVC control '{c.Name}' min={mn} max={mx} step={st} default={df} value={cv} auto={autoSup} for '{camera.Name}'");
+                }
+            }
+
+            return controls;
+        }
+
+        /// <summary>
+        /// Checks if a UVC control is supported via UVC_GET_INFO.
+        /// </summary>
+        private bool ControlSupported(byte entityId, byte selector)
+        {
+            byte[] info = new byte[1];
+            int ret = LibUvc.uvc_get_ctrl(_devh, entityId, selector, info, 1, LibUvc.UVC_GET_INFO);
+            return ret > 0 && (info[0] & 0x03) != 0;
+        }
+
+        /// <summary>
+        /// Reads a UVC control value using the generic uvc_get_ctrl API.
+        /// </summary>
+        private long ReadCtrlGeneric(byte entityId, byte selector, int dataLen, bool isSigned, byte req)
+        {
+            byte[] buf = new byte[dataLen];
+            int ret = LibUvc.uvc_get_ctrl(_devh, entityId, selector, buf, dataLen, req);
+            if (ret < 0)
+            {
+                logger.Debug($"ReadCtrlGeneric failed: entityId={entityId}, selector=0x{selector:X2}, error={LibUvc.ErrorName(ret)}");
+                return 0;
+            }
+
+            return dataLen switch
+            {
+                1 => isSigned ? (sbyte)buf[0] : buf[0],
+                2 => isSigned ? (short)(buf[0] | (buf[1] << 8)) : (ushort)(buf[0] | (buf[1] << 8)),
+                4 => isSigned ? (int)(buf[0] | (buf[1] << 8) | (buf[2] << 16) | (buf[3] << 24))
+                              : (uint)(buf[0] | (buf[1] << 8) | (buf[2] << 16) | (buf[3] << 24)),
+                _ => 0
+            };
+        }
+
+        private (bool autoSup, bool isAuto) CheckAuto(string? autoName)
+        {
+            if (string.IsNullOrEmpty(autoName)) return (false, false);
+
+            var autoDef = AutoControls.FirstOrDefault(a => a.Name == autoName);
+            if (autoDef == null) return (false, false);
+
+            byte entityId = autoName is "AutoExposure" or "AutoFocus" ? _ctId : _puId;
+            if (!ControlSupported(entityId, autoDef.Selector)) return (false, false);
+
+            byte[] buf = new byte[1];
+            int ret = LibUvc.uvc_get_ctrl(_devh, entityId, autoDef.Selector, buf, 1, LibUvc.UVC_GET_CUR);
+            return (true, ret > 0 && buf[0] != 0);
+        }
+
+        // -------------------------------------------------------------------
+        // Control set (called from CameraControlService via MacOSCameraDetect)
+        // -------------------------------------------------------------------
+
+        public bool SetControl(string controlName, long value)
+        {
+            if (_devh == IntPtr.Zero)
+            {
+                logger.Warn($"Ignoring UVC control set because device handle is closed: control='{controlName}', value={value}");
+                return false;
+            }
+
+            int ret = controlName switch
+            {
+                "Brightness"            => LibUvc.uvc_set_brightness(_devh, (short)value),
+                "Contrast"              => LibUvc.uvc_set_contrast(_devh, (ushort)value),
+                "Gain"                  => LibUvc.uvc_set_gain(_devh, (ushort)value),
+                "Hue"                   => LibUvc.uvc_set_hue(_devh, (short)value),
+                "Saturation"            => LibUvc.uvc_set_saturation(_devh, (ushort)value),
+                "Sharpness"             => LibUvc.uvc_set_sharpness(_devh, (ushort)value),
+                "Gamma"                 => LibUvc.uvc_set_gamma(_devh, (ushort)value),
+                "WhiteBalance"          => LibUvc.uvc_set_white_balance_temperature(_devh, (ushort)value),
+                "BacklightCompensation" => LibUvc.uvc_set_backlight_compensation(_devh, (ushort)value),
+                "PowerLineFrequency"    => LibUvc.uvc_set_power_line_frequency(_devh, (byte)value),
+                "ExposureTime"          => LibUvc.uvc_set_exposure_abs(_devh, (uint)value),
+                "FocusAbsolute"         => LibUvc.uvc_set_focus_abs(_devh, (ushort)value),
+                "Zoom_Absolute"         => LibUvc.uvc_set_zoom_abs(_devh, (ushort)value),
+                "Iris"                  => LibUvc.uvc_set_iris_abs(_devh, (ushort)value),
+                "Roll"                  => LibUvc.uvc_set_roll_abs(_devh, (short)value),
+                _ => SetControlGeneric(controlName, value)
+            };
+
+            if (ret == LibUvc.UVC_SUCCESS)
+            {
+                logger.Info($"UVC control '{controlName}' set to {value}: {LibUvc.ErrorName(ret)}");
+                return true;
+            }
+            else
+            {
+                logger.Warn($"Failed to set UVC control '{controlName}' to {value}: {LibUvc.ErrorName(ret)}");
+                return false;
+            }
+        }
+
+        private int SetControlGeneric(string controlName, long value)
+        {
+            var (entityId, def) = FindControl(controlName);
+            if (def == null)
+            {
+                logger.Warn($"Unknown UVC control '{controlName}'");
+                return LibUvc.UVC_ERROR_NOT_FOUND;
+            }
+
+            byte[] buf = new byte[def.DataLen];
+            switch (def.DataLen)
+            {
+                case 1: buf[0] = (byte)value; break;
+                case 2: buf[0] = (byte)(value & 0xFF); buf[1] = (byte)((value >> 8) & 0xFF); break;
+                case 4: buf[0] = (byte)(value & 0xFF); buf[1] = (byte)((value >> 8) & 0xFF);
+                        buf[2] = (byte)((value >> 16) & 0xFF); buf[3] = (byte)((value >> 24) & 0xFF); break;
+            }
+
+            return LibUvc.uvc_set_ctrl(_devh, entityId, def.Selector, buf, def.DataLen);
+        }
+
+        public bool SetAutoControl(string controlName, bool isAuto)
+        {
+            if (_devh == IntPtr.Zero)
+            {
+                logger.Warn($"Ignoring UVC auto-control set because device handle is closed: control='{controlName}', isAuto={isAuto}");
+                return false;
+            }
+
+            int ret = controlName switch
+            {
+                "AutoExposure"      => LibUvc.uvc_set_ae_mode(_devh, (byte)(isAuto ? 2 : 1)), // 2=auto, 1=manual
+                "AutoFocus"         => LibUvc.uvc_set_focus_auto(_devh, (byte)(isAuto ? 1 : 0)),
+                "AutoWhiteBalance"  => LibUvc.uvc_set_white_balance_temperature_auto(_devh, (byte)(isAuto ? 1 : 0)),
+                "HueAuto"           => LibUvc.uvc_set_hue_auto(_devh, (byte)(isAuto ? 1 : 0)),
+                "ContrastAuto"      => LibUvc.uvc_set_contrast_auto(_devh, (byte)(isAuto ? 1 : 0)),
+                _ => SetAutoControlGeneric(controlName, isAuto)
+            };
+
+            if (ret == LibUvc.UVC_SUCCESS)
+            {
+                logger.Info($"UVC auto control '{controlName}' set to {isAuto}: {LibUvc.ErrorName(ret)}");
+                return true;
+            }
+            else
+            {
+                logger.Warn($"Failed to set UVC auto control '{controlName}' to {isAuto}: {LibUvc.ErrorName(ret)}");
+                return false;
+            }
+        }
+
+        private int SetAutoControlGeneric(string controlName, bool isAuto)
+        {
+            var autoDef = AutoControls.FirstOrDefault(a => a.Name == controlName);
+            if (autoDef == null)
+            {
+                logger.Warn($"Unknown UVC auto control '{controlName}'");
+                return LibUvc.UVC_ERROR_NOT_FOUND;
+            }
+
+            byte entityId = controlName is "AutoExposure" or "AutoFocus" ? _ctId : _puId;
+            byte[] buf = [(byte)(isAuto ? 1 : 0)];
+            return LibUvc.uvc_set_ctrl(_devh, entityId, autoDef.Selector, buf, 1);
+        }
+
+        private (byte entityId, ControlDef? def) FindControl(string name)
+        {
+            bool preferAliases = _puId == _ctId;
+
+            if (preferAliases)
+            {
+                if (name == "ExposureTime") return (_puId, PuControls.First(c => c.Selector == UVC_PU_GAIN));
+                if (name == "FocusAbsolute") return (_puId, PuControls.First(c => c.Selector == UVC_PU_HUE));
+            }
+
+            foreach (var c in PuControls)
+                if (c.Name == name) return (_puId, c);
+            foreach (var c in CtControls)
+                if (c.Name == name) return (_ctId, c);
+            return (0, null);
+        }
+
+        // -------------------------------------------------------------------
+        // Streaming
+        // -------------------------------------------------------------------
+
+        private bool StartStreaming(Camera camera)
+        {
+            // Find the best available format by parsing the format descriptors.
+            // We prefer MJPEG at the highest resolution ≤ 1920×1080.
+            var (fmt, width, height, fps) = FindBestFormat();
+
+            if (fmt == LibUvc.UVC_FRAME_FORMAT_UNKNOWN || width == 0)
+            {
+                logger.Error("No suitable UVC streaming format found");
+                return false;
+            }
+
+            logger.Info($"UVC streaming: requesting {width}×{height}@{fps}fps format={fmt} (MJPEG=7)");
+
+            // Negotiate the stream control block via probe/commit
+            LibUvc.uvc_stream_ctrl_t ctrl = default;
+            int ret = LibUvc.uvc_get_stream_ctrl_format_size(
+                _devh, ref ctrl, fmt, width, height, fps);
+
+            if (ret != LibUvc.UVC_SUCCESS)
+            {
+                logger.Error($"uvc_get_stream_ctrl_format_size failed: {LibUvc.ErrorName(ret)}");
+                return false;
+            }
+
+            _width = width;
+            _height = height;
+            logger.Info($"UVC probe: format={ctrl.bFormatIndex}, frame={ctrl.bFrameIndex}, " +
+                        $"maxFrameSize={ctrl.dwMaxVideoFrameSize}, maxPayload={ctrl.dwMaxPayloadTransferSize}");
+
+            // Set up the frame callback — store as field to prevent GC collection
+            _frameCallback = OnFrameCallback;
+            _running = true;
+            _loggedNonMjpeg = false;
+
+            ret = LibUvc.uvc_start_streaming(_devh, ref ctrl, _frameCallback, IntPtr.Zero, 0);
+            if (ret != LibUvc.UVC_SUCCESS)
+            {
+                logger.Error($"uvc_start_streaming failed: {LibUvc.ErrorName(ret)}");
+                _running = false;
+                return false;
+            }
+
+            logger.Info($"UVC streaming started ({_width}×{_height})");
+            return true;
+        }
+
+        /// <summary>
+        /// Parses the format/frame descriptors to find the best MJPEG stream.
+        /// Falls back to the first available format if MJPEG is not supported.
+        /// </summary>
+        private (int format, int width, int height, int fps) FindBestFormat()
+        {
+            int bestFormat = LibUvc.UVC_FRAME_FORMAT_UNKNOWN;
+            int bestWidth = 0;
+            int bestHeight = 0;
+            int bestFps = 30;
+
+            IntPtr formatDescs = LibUvc.uvc_get_format_descs(_devh);
+            if (formatDescs == IntPtr.Zero)
+            {
+                logger.Warn("No format descriptors found");
+                return (bestFormat, bestWidth, bestHeight, bestFps);
+            }
+
+            // Walk the linked list of format descriptors.
+            // uvc_format_desc_t layout (64-bit, with utlist prev/next):
+            //   parent:     offset 0   (ptr, 8 bytes)
+            //   prev:       offset 8   (ptr, 8 bytes)
+            //   next:       offset 16  (ptr, 8 bytes)
+            //   bDescriptorSubtype: offset 24  (enum=int, 4 bytes)
+            //   bFormatIndex:      offset 28  (byte)
+            //   bNumFrameDescriptors: offset 29 (byte)
+            //   guidFormat/fourcc:  offset 30  (16 bytes union)
+            //   bBitsPerPixel:     offset 46  (byte)
+            //   bDefaultFrameIndex: offset 47 (byte)
+            //   bAspectRatioX:     offset 48  (byte)
+            //   bAspectRatioY:     offset 49  (byte)
+            //   bmInterlaceFlags:  offset 50  (byte)
+            //   bCopyProtect:      offset 51  (byte)
+            //   frame_descs:       offset 56  (ptr, 8 bytes — aligned to 8)
+            int offSubtype = IntPtr.Size * 3;
+            int offFormatIndex = IntPtr.Size * 3 + 4;
+            int offFourcc = IntPtr.Size * 3 + 4 + 1;
+            int offFrameDescsPtr = 56; // aligned after 6 bytes of trailing fields
+
+            IntPtr currentFormat = formatDescs;
+            int formatIdx = 0;
+
+            while (currentFormat != IntPtr.Zero && formatIdx < 20)
+            {
+                int subtype = Marshal.ReadInt32(currentFormat, offSubtype);
+                byte fmtIdx = Marshal.ReadByte(currentFormat, offFormatIndex);
+                byte[] fourcc = new byte[4];
+                Marshal.Copy(currentFormat + offFourcc, fourcc, 0, 4);
+                string fourccStr = System.Text.Encoding.ASCII.GetString(fourcc);
+
+                bool isMjpeg = subtype == LibUvc.UVC_VS_FORMAT_MJPEG || fourccStr == "MJPG";
+                logger.Debug($"FindBestFormat: format[{formatIdx}] subtype=0x{subtype:X2} idx={fmtIdx} fourcc='{fourccStr}' mjep={isMjpeg}");
+
+                IntPtr frameDescsPtr = Marshal.ReadIntPtr(currentFormat, offFrameDescsPtr);
+                if (frameDescsPtr != IntPtr.Zero)
+                {
+                    // uvc_frame_desc_t layout (64-bit, with utlist prev/next):
+                    //   parent:     offset 0   (ptr)
+                    //   prev:       offset 8   (ptr)
+                    //   next:       offset 16  (ptr)
+                    //   bDescriptorSubtype: offset 24 (enum=int, 4 bytes)
+                    //   bFrameIndex:      offset 28  (byte)
+                    //   bmCapabilities:   offset 29  (byte)
+                    //   wWidth:           offset 30  (ushort)
+                    //   wHeight:          offset 32  (ushort)
+                    int fdOffFrameIdx = IntPtr.Size * 3 + 4;
+                    int fdOffWidth = IntPtr.Size * 3 + 4 + 1 + 1;
+                    int fdOffHeight = fdOffWidth + 2;
+
+                    IntPtr currentFrame = frameDescsPtr;
+                    int frameIdx = 0;
+
+                    while (currentFrame != IntPtr.Zero && frameIdx < 30)
+                    {
+                        byte frameIndex = Marshal.ReadByte(currentFrame, fdOffFrameIdx);
+                        ushort w = (ushort)(Marshal.ReadByte(currentFrame, fdOffWidth) | (Marshal.ReadByte(currentFrame, fdOffWidth + 1) << 8));
+                        ushort h = (ushort)(Marshal.ReadByte(currentFrame, fdOffHeight) | (Marshal.ReadByte(currentFrame, fdOffHeight + 1) << 8));
+
+                        logger.Debug($"FindBestFormat:   frame[{frameIdx}] idx={frameIndex} {w}×{h}");
+
+                        // Prefer MJPEG at highest resolution ≤ 1920×1080
+                        if (isMjpeg && w > 0 && h > 0 && w <= 1920 && h <= 1080)
+                        {
+                            if (bestFormat != LibUvc.UVC_FRAME_FORMAT_MJPEG || (w * h > bestWidth * bestHeight))
+                            {
+                                bestFormat = LibUvc.UVC_FRAME_FORMAT_MJPEG;
+                                bestWidth = w;
+                                bestHeight = h;
+                            }
+                        }
+                        // Fallback: accept any format at a reasonable resolution
+                        else if (bestFormat == LibUvc.UVC_FRAME_FORMAT_UNKNOWN && w > 0 && h > 0 && w <= 1920 && h <= 1080)
+                        {
+                            bestFormat = LibUvc.UVC_FRAME_FORMAT_YUYV;
+                            bestWidth = w;
+                            bestHeight = h;
+                        }
+
+                        currentFrame = Marshal.ReadIntPtr(currentFrame, IntPtr.Size * 2); // next
+                        frameIdx++;
+                    }
+                }
+
+                currentFormat = Marshal.ReadIntPtr(currentFormat, IntPtr.Size * 2); // next
+                formatIdx++;
+            }
+
+            if (bestFormat == LibUvc.UVC_FRAME_FORMAT_UNKNOWN)
+            {
+                logger.Warn("FindBestFormat: no format found via descriptor walk, trying MJPEG 640×480 fallback");
+                bestFormat = LibUvc.UVC_FRAME_FORMAT_MJPEG;
+                bestWidth = 640;
+                bestHeight = 480;
+            }
+
+            return (bestFormat, bestWidth, bestHeight, bestFps);
+        }
+
+        // -------------------------------------------------------------------
+        // Frame callback (called by libuvc on the streaming thread)
+        // -------------------------------------------------------------------
+
+        private void OnFrameCallback(IntPtr framePtr, IntPtr userPtr)
+        {
+            if (!_running || framePtr == IntPtr.Zero) return;
+
+            try
+            {
+                var frame = Marshal.PtrToStructure<LibUvc.uvc_frame_t>(framePtr);
+                if (frame.data == IntPtr.Zero || (long)frame.data_bytes == 0) return;
+
+                // Update dimensions from the frame
+                if (_width == 0 || _height == 0)
+                {
+                    _width = (int)frame.width;
+                    _height = (int)frame.height;
+                    logger.Info($"UVC frame dimensions from callback: {frame.width}×{frame.height}");
+                }
+
+                int dataLen = (int)(long)frame.data_bytes;
+                byte[] frameData = new byte[dataLen];
+                Marshal.Copy(frame.data, frameData, 0, dataLen);
+
+                // For MJPEG, frameData is a complete JPEG — deliver to FrameRenderer.
+                if (frame.frame_format == LibUvc.UVC_FRAME_FORMAT_MJPEG)
+                {
+                    FrameReady?.Invoke(frameData, _width, _height);
+                }
+                else
+                {
+                    // Uncompressed format (YUYV, etc.) — log once.
+                    // Could add YUYV→JPEG conversion later if needed.
+                    if (!_loggedNonMjpeg)
+                    {
+                        _loggedNonMjpeg = true;
+                        logger.Warn($"UVC frame format {frame.frame_format} is not MJPEG — frames are being dropped. " +
+                                    "Add YUYV→JPEG conversion or request MJPEG format from the camera.");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "Error in UVC frame callback");
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // Recovery (called from Program.cs --recover-uvc-vidpid)
+        // -------------------------------------------------------------------
+
+        /// <summary>
+        /// Restores the macOS kernel UVC driver by re-activating the device
+        /// configuration via IOKit SetConfiguration(1). Useful after a crash
+        /// that left the device detached from the kernel driver.
+        /// </summary>
+        internal static bool TryRecoverUvcDevice(int vendorId, int productId)
+        {
+            if (vendorId <= 0 || productId <= 0) return false;
+
+            try
+            {
+                logger.Info($"TryRecoverUvcDevice: VID={vendorId} PID={productId}");
+                IokitHelper.RestoreKernelDriver(vendorId, productId);
+                logger.Info("TryRecoverUvcDevice: recovery succeeded");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "TryRecoverUvcDevice: recovery threw exception");
+                return false;
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // IDisposable
+        // -------------------------------------------------------------------
+
+        public void Dispose()
+        {
+            Stop();
+        }
+    }
+}

--- a/CollimationCircles/StartupOptions.cs
+++ b/CollimationCircles/StartupOptions.cs
@@ -1,14 +1,44 @@
 using System;
+using System.Globalization;
 
 namespace CollimationCircles
 {
+    /// <summary>
+    /// Parses command-line options used at startup.
+    /// Supported commands:
+    /// --camera <name> or --camera=<name>
+    /// --camera-vidpid <vid:pid> or --camera-vidpid=<vid:pid>
+    /// --recover-uvc <vid:pid> or --recover-uvc=<vid:pid>
+    /// </summary>
     internal static class StartupOptions
     {
+        /// <summary>
+        /// Camera name to auto-connect at startup.
+        /// Command: --camera
+        /// Example: --camera "ocal4.1"
+        /// </summary>
         public static string? AutoConnectCameraName { get; private set; }
+
+        /// <summary>
+        /// Camera vendor/product pair to auto-connect at startup.
+        /// Command: --camera-vidpid
+        /// Example: --camera-vidpid 60324:4867
+        /// </summary>
+        public static (int VendorId, int ProductId)? AutoConnectCameraVidPid { get; private set; }
+
+        /// <summary>
+        /// Vendor/product pair used to run recovery-only mode and restore
+        /// the UVC device configuration without launching the UI.
+        /// Command: --recover-uvc
+        /// Example: --recover-uvc 60324:4867
+        /// </summary>
+        public static (int VendorId, int ProductId)? RecoverUvcVidPid { get; private set; }
 
         public static void Initialize(string[] args)
         {
             AutoConnectCameraName = null;
+            AutoConnectCameraVidPid = null;
+            RecoverUvcVidPid = null;
 
             if (args is null || args.Length == 0)
             {
@@ -19,11 +49,34 @@ namespace CollimationCircles
             {
                 string arg = args[i];
 
+                // --camera <name>
                 if (string.Equals(arg, "--camera", StringComparison.OrdinalIgnoreCase))
                 {
                     if (i + 1 < args.Length && !string.IsNullOrWhiteSpace(args[i + 1]))
                     {
                         AutoConnectCameraName = args[i + 1].Trim();
+                    }
+
+                    continue;
+                }
+
+                // --camera-vidpid <vid:pid>
+                if (string.Equals(arg, "--camera-vidpid", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (i + 1 < args.Length)
+                    {
+                        AutoConnectCameraVidPid = ParseVidPid(args[i + 1]);
+                    }
+
+                    continue;
+                }
+
+                // --recover-uvc <vid:pid>
+                if (string.Equals(arg, "--recover-uvc", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (i + 1 < args.Length)
+                    {
+                        RecoverUvcVidPid = ParseVidPid(args[i + 1]);
                     }
 
                     continue;
@@ -37,8 +90,60 @@ namespace CollimationCircles
                     {
                         AutoConnectCameraName = value;
                     }
+
+                    continue;
+                }
+
+                const string cameraVidPidPrefix = "--camera-vidpid=";
+                if (arg.StartsWith(cameraVidPidPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    AutoConnectCameraVidPid = ParseVidPid(arg[cameraVidPidPrefix.Length..]);
+                    continue;
+                }
+
+                const string recoverUvcPrefix = "--recover-uvc=";
+                if (arg.StartsWith(recoverUvcPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    RecoverUvcVidPid = ParseVidPid(arg[recoverUvcPrefix.Length..]);
                 }
             }
+        }
+
+        private static (int VendorId, int ProductId)? ParseVidPid(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            string[] parts = value.Trim().Split(':', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length != 2)
+            {
+                return null;
+            }
+
+            if (!TryParseId(parts[0], out int vendorId) || !TryParseId(parts[1], out int productId))
+            {
+                return null;
+            }
+
+            if (vendorId <= 0 || productId <= 0)
+            {
+                return null;
+            }
+
+            return (vendorId, productId);
+        }
+
+        private static bool TryParseId(string value, out int id)
+        {
+            value = value.Trim();
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                return int.TryParse(value[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out id);
+            }
+
+            return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out id);
         }
     }
 }

--- a/CollimationCircles/ViewModels/StreamViewModel.cs
+++ b/CollimationCircles/ViewModels/StreamViewModel.cs
@@ -79,7 +79,26 @@ namespace CollimationCircles.ViewModels
             Dispatcher.UIThread.Post(async () =>
             {
                 CameraList = [.. await cameraControlService.GetCameraList()];
-                SelectedCamera = CameraList?.Where(c => c.Name == settingsViewModel.LastSelectedCamera)?.FirstOrDefault() ?? CameraList?.FirstOrDefault() ?? new();
+                SelectedCamera = CameraList.Where(c => c.Name == settingsViewModel.LastSelectedCamera).FirstOrDefault()
+                    ?? CameraList.FirstOrDefault()
+                    ?? new();
+
+                if (StartupOptions.AutoConnectCameraVidPid is { } targetVidPid && CameraList.Count > 0)
+                {
+                    Camera? vidPidCamera = CameraList.FirstOrDefault(c =>
+                        c.VendorId == targetVidPid.VendorId &&
+                        c.ProductId == targetVidPid.ProductId);
+
+                    if (vidPidCamera is not null)
+                    {
+                        SelectedCamera = vidPidCamera;
+                        logger.Info($"Startup option --camera-vidpid matched '{SelectedCamera.Name}' (VID={targetVidPid.VendorId} PID={targetVidPid.ProductId}). Starting stream automatically.");
+                        await StartSelectedCameraAsync();
+                        return;
+                    }
+
+                    logger.Warn($"Startup option --camera-vidpid='{targetVidPid.VendorId}:{targetVidPid.ProductId}' did not match any discovered camera.");
+                }
 
                 if (!string.IsNullOrWhiteSpace(StartupOptions.AutoConnectCameraName) && CameraList.Count > 0)
                 {
@@ -121,7 +140,7 @@ namespace CollimationCircles.ViewModels
             logger.Trace($"MediaPlayer opening");
 
             ShowWebCamStream();
-            IsPlaying = SelectedCamera?.APIType == APIType.Zwo || libVLCService.MediaPlayer?.IsPlaying == true;
+            IsPlaying = SelectedCamera?.APIType is APIType.Zwo or APIType.Uvc || libVLCService.MediaPlayer?.IsPlaying == true;
             if (SelectedCamera is not null)
             {
                 SelectedCamera.IsPlaying = IsPlaying;
@@ -133,7 +152,7 @@ namespace CollimationCircles.ViewModels
             Guard.IsNotNull(SelectedCamera);
 
             logger.Trace($"MediaPlayer playing");
-            IsPlaying = SelectedCamera.APIType == APIType.Zwo || libVLCService.MediaPlayer?.IsPlaying == true;
+            IsPlaying = SelectedCamera.APIType is APIType.Zwo or APIType.Uvc || libVLCService.MediaPlayer?.IsPlaying == true;
             SelectedCamera.IsPlaying = IsPlaying;
         }
 
@@ -159,6 +178,8 @@ namespace CollimationCircles.ViewModels
         {
             Guard.IsNotNull(SelectedCamera);
 
+            logger.Info($"PlayPause clicked: camera='{SelectedCamera.Name}', APIType={SelectedCamera.APIType}, FullAddress='{FullAddress}'");
+
             // ZWO cameras use a direct-rendering path that bypasses LibVLC entirely.
             if (SelectedCamera.APIType == APIType.Zwo)
             {
@@ -172,6 +193,31 @@ namespace CollimationCircles.ViewModels
                 else
                 {
                     await libVLCService.Play(SelectedCamera, DisplayAdvancedDShowDialog);
+                }
+
+                return;
+            }
+
+            // UVC cameras on macOS use a direct-rendering path that bypasses LibVLC entirely.
+            if (SelectedCamera.APIType == APIType.Uvc)
+            {
+                var uvcFrameSource = Ioc.Default.GetRequiredService<IUvcFrameSource>();
+
+                if (uvcFrameSource.IsStreaming)
+                {
+                    uvcFrameSource.Stop();
+                    MediaPlayer_Closed();
+                }
+                else
+                {
+                    try
+                    {
+                        await libVLCService.Play(SelectedCamera, DisplayAdvancedDShowDialog);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Error(ex, $"Error starting UVC stream for '{SelectedCamera.Name}'");
+                    }
                 }
 
                 return;

--- a/CollimationCircles/Views/StreamView.axaml.cs
+++ b/CollimationCircles/Views/StreamView.axaml.cs
@@ -29,7 +29,9 @@ namespace CollimationCircles.Views
         private bool vlcCropCleared = false;
 
         private IZwoFrameSource? _zwoFrameSource;
+        private IUvcFrameSource? _uvcFrameSource;
         private bool _usingZwoDirect;
+        private bool _usingUvcDirect;
 
         public StreamView()
         {
@@ -65,6 +67,12 @@ namespace CollimationCircles.Views
                 _zwoFrameSource = null;
             }
 
+            if (_uvcFrameSource is not null)
+            {
+                _uvcFrameSource.FrameReady -= OnUvcFrameReady;
+                _uvcFrameSource = null;
+            }
+
             if (frameGrid is not null)
                 frameGrid.SizeChanged -= OnFrameGridSizeChanged;
         }
@@ -72,19 +80,30 @@ namespace CollimationCircles.Views
         private void WebCamStreamWindow_Opened(object? sender, System.EventArgs e)
         {
             _zwoFrameSource = Ioc.Default.GetRequiredService<IZwoFrameSource>();
+            _uvcFrameSource = Ioc.Default.GetRequiredService<IUvcFrameSource>();
             _usingZwoDirect = _zwoFrameSource.IsStreaming;
+            _usingUvcDirect = _uvcFrameSource.IsStreaming;
 
-            if (_usingZwoDirect)
+            if (_usingZwoDirect || _usingUvcDirect)
             {
-                // ZWO direct-rendering path: show FrameRenderer, hide VideoView.
+                // Direct-rendering path: show FrameRenderer, hide VideoView.
                 if (videoViewer is not null) videoViewer.IsVisible = false;
                 if (frameGrid is not null) frameGrid.IsVisible = true;
 
-                sourceVideoWidth = _zwoFrameSource.FrameWidth;
-                sourceVideoHeight = _zwoFrameSource.FrameHeight;
-                sourceDimensionsCaptured = sourceVideoWidth > 0 && sourceVideoHeight > 0;
-
-                _zwoFrameSource.FrameReady += OnZwoFrameReady;
+                if (_usingZwoDirect)
+                {
+                    sourceVideoWidth = _zwoFrameSource.FrameWidth;
+                    sourceVideoHeight = _zwoFrameSource.FrameHeight;
+                    sourceDimensionsCaptured = sourceVideoWidth > 0 && sourceVideoHeight > 0;
+                    _zwoFrameSource.FrameReady += OnZwoFrameReady;
+                }
+                else if (_usingUvcDirect)
+                {
+                    sourceVideoWidth = _uvcFrameSource.FrameWidth;
+                    sourceVideoHeight = _uvcFrameSource.FrameHeight;
+                    sourceDimensionsCaptured = sourceVideoWidth > 0 && sourceVideoHeight > 0;
+                    _uvcFrameSource.FrameReady += OnUvcFrameReady;
+                }
 
                 if (frameGrid is not null)
                     frameGrid.SizeChanged += OnFrameGridSizeChanged;
@@ -146,7 +165,29 @@ namespace CollimationCircles.Views
 
         private void OnZwoFrameReady(byte[] frame, int width, int height)
         {
-            frameRenderer?.SetJpegFrame(frame);
+            // Same rendering logic for both ZWO and UVC frames
+            OnDirectFrameReady(frame, width, height);
+        }
+
+        private void OnUvcFrameReady(byte[] frame, int width, int height)
+        {
+            OnDirectFrameReady(frame, width, height);
+        }
+
+        private void OnDirectFrameReady(byte[] frame, int width, int height)
+        {
+            if (!sourceDimensionsCaptured && width > 0 && height > 0)
+            {
+                sourceVideoWidth = width;
+                sourceVideoHeight = height;
+                sourceDimensionsCaptured = true;
+                logger.Info($"Captured source video dimensions from direct frame: {width}x{height}");
+            }
+
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                frameRenderer?.SetJpegFrame(frame);
+            });
         }
 
         private void ApplyZoom(ImageZoomAction action)
@@ -173,7 +214,7 @@ namespace CollimationCircles.Views
 
         private void UpdateImageTransform()
         {
-            if (_usingZwoDirect)
+            if (_usingZwoDirect || _usingUvcDirect)
             {
                 if (frameRenderer is not null)
                     frameRenderer.Zoom = currentZoom;

--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ sudo apt-get install -y v4l-utils
 - libcamera-vid for detecting Raspberry Pi Cameras. It should already be installed on Raspberry Pi OS by default.
   - instalation instructions https://libcamera.org/getting-started.html
 
+## macOS camera control
+
+On macOS, UVC camera control (brightness, contrast, gain, exposure, sharpness, etc.) and streaming use [libuvc](https://github.com/libuvc/libuvc) (built from source with macOS-specific patches) on top of [libusb](https://github.com/libusb/libusb). This bypasses the macOS kernel UVC driver and gives the same level of control as `v4l2-ctl` on Linux and DirectShow on Windows.
+
+Cameras that are not UVC-compliant (e.g. FaceTime HD, OBS Virtual Camera, iPhone Continuity Camera) fall back to VLC's `avcapture` input via AVFoundation, with controls (exposure, focus, white balance) discovered through AVFoundation Swift scripts.
+
+The `libusb-1.0.0.dylib` and `libuvc.dylib` are bundled with the app — end users do **not** need to install them. Developers building from source on macOS need:
+
+```
+brew install libusb cmake
+```
+
+Both dylibs are copied to the build output by MSBuild targets and included in the `.app` bundle by the publish scripts.
+
+On macOS, this command can be run to list the available cameras:
+
+```
+system_profiler SPCameraDataType -json
+```
+
 # Prebuild binaries
 Here are prebuild binary files available for you to download (win-x64, linux-x64, linux-arm64, osx-x64 and osx-arm64).
 https://github.com/sajmons/CollimationCircles/releases/
@@ -199,9 +219,9 @@ cd CollimationCircles
 
 Restore/build/run:
 ```
-dotnet restore ./CollimationCircles/CollimationCircles.csproj -r osx-arm64
-dotnet build ./CollimationCircles/CollimationCircles.csproj -f net10.0
-dotnet run --project ./CollimationCircles/CollimationCircles.csproj -f net10.0
+dotnet restore ./CollimationCircles/CollimationCircles.csproj -c Debug -r osx-arm64
+dotnet build CollimationCircles/CollimationCircles.csproj -c Debug -r osx-arm64
+dotnet run --project CollimationCircles/CollimationCircles.csproj -c Debug -r osx-arm64
 ```
 
 Notes:


### PR DESCRIPTION
Fixes https://github.com/sajmons/CollimationCircles/issues/61

This PR changes the underlying platform used to stream and control UVC cameras **for macOS only**.

Before, avcapture and macOS AVFoundation was used, which are very limited in controls (basically nothing).

Now, any UVC kind camera will be streamed and controlled through libuvc (which is available on all platforms).

Controls are auto-detected and work fine (gain, exposure, zoom, sharpness, etc).