### PR TITLE
fix(macOS): restore AVFoundation control discovery/logging and clarify mode-only controls

### DIFF
--- a/CollimationCircles/Controls/DynamicCameraControlsUserControl.axaml
+++ b/CollimationCircles/Controls/DynamicCameraControlsUserControl.axaml
@@ -26,9 +26,15 @@
   </UserControl.Styles>
   <StackPanel
     Orientation="Vertical"
-    Spacing="20"
-    IsVisible="{Binding IsPlaying}">
-    <ItemsControl ItemsSource="{Binding Camera.Controls}" >
+    Spacing="20">
+    <TextBlock
+      IsVisible="{Binding !HasCameraControls}"
+      Text="No adjustable camera settings are exposed for this camera on macOS AVFoundation."
+      TextWrapping="Wrap" />
+
+    <ItemsControl
+      IsVisible="{Binding HasCameraControls}"
+      ItemsSource="{Binding Camera.Controls}" >
       <ItemsControl.ItemTemplate>
         <DataTemplate>
           <Grid
@@ -44,6 +50,7 @@
             <Slider
               Grid.RowSpan="3"
               Grid.ColumnSpan="2"
+              IsVisible="{Binding !IsModeOnly}"
               Value="{Binding Value}"
               Minimum="{Binding Min}"
               Maximum="{Binding Max}"
@@ -51,8 +58,16 @@
             <TextBox
               Grid.Row="1"
               Grid.Column="1"
+              IsVisible="{Binding !IsModeOnly}"
               IsEnabled="{Binding !IsAuto}"
               Text="{Binding Value}"/>
+            <TextBlock
+              Grid.Row="1"
+              Grid.Column="0"
+              Grid.ColumnSpan="2"
+              IsVisible="{Binding IsModeOnly}"
+              Opacity="0.8"
+              Text="Mode control: use Auto toggle (Auto vs Locked)." />
           </Grid>
         </DataTemplate>
       </ItemsControl.ItemTemplate>

--- a/CollimationCircles/Models/CameraControl.cs
+++ b/CollimationCircles/Models/CameraControl.cs
@@ -14,6 +14,7 @@ namespace CollimationCircles.Models
         public int Default { get; set; }
         public ControlValueType ValueType { get; set; }
         public bool AutoSupported { get; set; }
+        public bool IsModeOnly { get; set; }
 
         [ObservableProperty]
         private int value;

--- a/CollimationCircles/Models/ICameraControl.cs
+++ b/CollimationCircles/Models/ICameraControl.cs
@@ -9,6 +9,7 @@
         public int Default { get; set; }
         public int Value { get; set; }
         public bool AutoSupported { get; set; }
+        public bool IsModeOnly { get; set; }
         public bool IsAuto { get; set; }
         public string Flags { get; set; }
         public void SetDefault();

--- a/CollimationCircles/Program.cs
+++ b/CollimationCircles/Program.cs
@@ -26,6 +26,8 @@ namespace CollimationCircles
         [STAThread]
         public static void Main(string[] args)
         {
+            StartupOptions.Initialize(args);
+
             // Disable the NLog console target when stdout is not connected to a terminal.
             // Without this, the pipe buffer (~64 KB) fills from verbose logging and every
             // subsequent log call blocks indefinitely, making the window appear frozen.

--- a/CollimationCircles/Services/CameraControlService.cs
+++ b/CollimationCircles/Services/CameraControlService.cs
@@ -15,6 +15,8 @@ namespace CollimationCircles.Services
             Guard.IsNotNull(camera);
             Guard.IsTrue(camera.IsPlaying);
 
+            logger.Info($"Setting update requested: camera='{camera.Name}', api={camera.APIType}, control={controlName}, value={value}");
+
             // set camera control for V4L2 (Linux cameras)
             if (camera.APIType is APIType.V4l2)
             {
@@ -46,9 +48,15 @@ namespace CollimationCircles.Services
         {
             Guard.IsNotNull(camera);
 
+            logger.Info($"Auto-setting update requested: camera='{camera.Name}', api={camera.APIType}, control={controlName}, isAuto={isAuto}");
+
             if (camera.APIType is APIType.Zwo)
             {
                 new ZWOCameraDetect().SetControlAuto(camera, controlName, isAuto);
+            }
+            else if (camera.APIType is APIType.QTCapture)
+            {
+                new MacOSCameraDetect().SetControlAuto(camera, controlName, isAuto);
             }
         }
 

--- a/CollimationCircles/Services/MacOSCameraDetect.cs
+++ b/CollimationCircles/Services/MacOSCameraDetect.cs
@@ -3,9 +3,8 @@ using CommunityToolkit.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
+using System.IO;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace CollimationCircles.Services
@@ -14,10 +13,28 @@ namespace CollimationCircles.Services
     {
         private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
+        private sealed class AvFoundationControlDto
+        {
+            public string Name { get; set; } = string.Empty;
+            public int Min { get; set; }
+            public int Max { get; set; }
+            public double Step { get; set; }
+            public int Default { get; set; }
+            public int Current { get; set; }
+            public bool AutoSupported { get; set; }
+            public bool IsAuto { get; set; }
+        }
+
+        private sealed class AvFoundationControlsResponse
+        {
+            public List<AvFoundationControlDto> Controls { get; set; } = [];
+        }
+
         public Dictionary<ControlType, object> ControlMapping => new()
         {
-            { ControlType.Gain, "gain" },
-            { ControlType.ExposureTime, "exposure" }
+            { ControlType.ExposureTime, "ExposureTime" },
+            { ControlType.FocusAbsolute, "FocusAbsolute" },
+            { ControlType.WhiteBalance, "WhiteBalance" }
         };
 
         public async Task<List<Camera>> GetCameras()
@@ -29,9 +46,7 @@ namespace CollimationCircles.Services
                 return cameras;
             }
 
-            // First, try to get cameras from system_profiler (built-in cameras)
             await DetectSystemProfilerCameras(cameras);
-
             return cameras;
         }
 
@@ -113,159 +128,159 @@ namespace CollimationCircles.Services
             return propertyElement.GetString();
         }
 
-        private async Task DetectUSBCameras(List<Camera> cameras)
-        {
-            try
-            {
-                // Try two methods: ioreg and system_profiler
-                
-                // Method 1: Try ioreg (more detailed but may require more parsing)
-                await TryDetectViaIoreg(cameras);
-                
-                // Method 2: Try system_profiler SPUSBDataType (more reliable)
-                await TryDetectViaSystemProfilerUSB(cameras);
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex, "Error while detecting USB cameras");
-            }
-        }
-
-        private async Task TryDetectViaIoreg(List<Camera> cameras)
-        {
-            try
-            {
-                var (errorCode, result) = await AppService.StartProcessAsync(
-                    "ioreg",
-                    ["-p", "IOUSB"]);
-
-                if (errorCode == 0)
-                {
-                    logger.Debug("ioreg output available, parsing for astro cameras");
-                    
-                    // Look for ASI cameras (ZWO)
-                    string asiPattern = @"ASI\s*([0-9]+[A-Z]*)";
-                    var matches = Regex.Matches(result, asiPattern, RegexOptions.IgnoreCase);
-
-                    int cameraIndex = 1;
-                    foreach (Match match in matches.Cast<Match>())
-                    {
-                        string name = $"ASI {match.Groups[1].Value}";
-                        
-                        if (!cameras.Any(c => c.Name == name))
-                        {
-                            Camera camera = new()
-                            {
-                                Index = cameras.Count,
-                                APIType = APIType.QTCapture,
-                                Name = name,
-                                Path = cameraIndex.ToString()
-                            };
-
-                            camera.Controls = await GetControls(camera);
-                            cameras.Add(camera);
-                            cameraIndex++;
-                            logger.Info($"Added camera via ioreg: '{camera.Name}'");
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.Debug($"ioreg detection failed (non-critical): {ex.Message}");
-            }
-        }
-
-        private async Task TryDetectViaSystemProfilerUSB(List<Camera> cameras)
-        {
-            try
-            {
-                var (errorCode, result) = await AppService.StartProcessAsync(
-                    "system_profiler",
-                    ["SPUSBDataType"]);
-
-                if (errorCode == 0)
-                {
-                    logger.Debug("SPUSBDataType output available, parsing for astro cameras");
-                    
-                    // Look for common astro camera product names
-                    string[] patterns = new[]
-                    {
-                        @"Product:\s+(.+?ASI.+?)(?=\n|$)",  // ZWO ASI cameras
-                        @"Product:\s+(.+?SV.+?)(?=\n|$)",   // SVBONY cameras
-                        @"Product:\s+(.+?QHY.+?)(?=\n|$)",  // QHY cameras
-                        @"Product:\s+(.+?TouCam.+?)(?=\n|$)" // Philips TouCam
-                    };
-
-                    int cameraIndex = 1;
-                    foreach (string pattern in patterns)
-                    {
-                        var matches = Regex.Matches(result, pattern, RegexOptions.IgnoreCase);
-                        
-                        foreach (Match match in matches.Cast<Match>())
-                        {
-                            string name = match.Groups[1].Value.Trim();
-                            
-                            if (!string.IsNullOrWhiteSpace(name) && !cameras.Any(c => c.Name == name))
-                            {
-                                Camera camera = new()
-                                {
-                                    Index = cameras.Count,
-                                    APIType = APIType.QTCapture,
-                                    Name = name,
-                                    Path = cameraIndex.ToString()
-                                };
-
-                                camera.Controls = await GetControls(camera);
-                                cameras.Add(camera);
-                                cameraIndex++;
-                                logger.Info($"Added USB camera via SPUSBDataType: '{camera.Name}'");
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.Debug($"SPUSBDataType detection failed (non-critical): {ex.Message}");
-            }
-        }
-
-        public Task<List<ICameraControl>> GetControls(Camera camera)
+        public async Task<List<ICameraControl>> GetControls(Camera camera)
         {
             Guard.IsNotNull(camera);
 
             List<ICameraControl> controls = [];
 
-            // Add Gain control for astro cameras (typical range: 0-600 for ZWO)
-            var gainControl = new CameraControl(ControlType.Gain, camera)
+            if (!OperatingSystem.IsMacOS() || camera.APIType is not APIType.QTCapture)
             {
-                Min = 0,
-                Max = 600,
-                Step = 1,
-                Default = 100,
-                Value = 100,
-                Flags = "ro",
-                ValueType = ControlValueType.Int
-            };
-            controls.Add(gainControl);
-            logger.Info($"Gain control added for '{camera.Name}'");
+                return controls;
+            }
 
-            // Add Exposure Time control (typical range: 1-10000 ms for astro cameras)
-            var exposureControl = new CameraControl(ControlType.ExposureTime, camera)
+            logger.Info($"Discovering AVFoundation settings for camera '{camera.Name}' ({camera.Path})");
+
+            string script = @"
+import Foundation
+import AVFoundation
+
+struct Control: Codable {
+    let name: String
+    let min: Int
+    let max: Int
+    let step: Double
+    let `default`: Int
+    let current: Int
+    let autoSupported: Bool
+    let isAuto: Bool
+}
+
+struct Payload: Codable {
+    let controls: [Control]
+}
+
+func clamp(_ value: Double, _ minValue: Double, _ maxValue: Double) -> Double {
+    return max(minValue, min(maxValue, value))
+}
+
+let deviceId = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : """"
+let cameraName = CommandLine.arguments.count > 2 ? CommandLine.arguments[2] : """"
+
+let devices = AVCaptureDevice.devices(for: .video)
+let device = devices.first { $0.uniqueID == deviceId }
+    ?? devices.first { $0.localizedName == cameraName }
+
+var controls: [Control] = []
+
+if let d = device {
+    if d.isExposureModeSupported(.continuousAutoExposure) || d.isExposureModeSupported(.locked) {
+        controls.append(Control(
+            name: ""ExposureTime"",
+            min: 0,
+            max: 0,
+            step: 1,
+            default: 0,
+            current: 0,
+            autoSupported: d.isExposureModeSupported(.continuousAutoExposure),
+            isAuto: d.exposureMode == .continuousAutoExposure
+        ))
+    }
+
+    if d.isFocusModeSupported(.continuousAutoFocus) || d.isFocusModeSupported(.locked) {
+        controls.append(Control(
+            name: ""FocusAbsolute"",
+            min: 0,
+            max: 0,
+            step: 1,
+            default: 0,
+            current: 0,
+            autoSupported: d.isFocusModeSupported(.continuousAutoFocus),
+            isAuto: d.focusMode == .continuousAutoFocus
+        ))
+    }
+
+    if d.isWhiteBalanceModeSupported(.continuousAutoWhiteBalance) || d.isWhiteBalanceModeSupported(.locked) {
+        controls.append(Control(
+            name: ""WhiteBalance"",
+            min: 0,
+            max: 0,
+            step: 1,
+            default: 0,
+            current: 0,
+            autoSupported: d.isWhiteBalanceModeSupported(.continuousAutoWhiteBalance),
+            isAuto: d.whiteBalanceMode == .continuousAutoWhiteBalance
+        ))
+    }
+}
+
+let payload = Payload(controls: controls)
+let data = try JSONEncoder().encode(payload)
+print(String(data: data, encoding: .utf8)!)
+";
+
+            List<string> swiftArgs = [camera.Path ?? string.Empty, camera.Name ?? string.Empty];
+            (int exitCode, string output) = await RunSwiftScriptAsync(script, swiftArgs);
+
+            if (exitCode != 0 || string.IsNullOrWhiteSpace(output))
             {
-                Min = 1,
-                Max = 10000,
-                Step = 1,
-                Default = 100,
-                Value = 100,
-                Flags = "ro",
-                ValueType = ControlValueType.Int
-            };
-            controls.Add(exposureControl);
-            logger.Info($"Exposure Time control added for '{camera.Name}'");
+                logger.Warn($"AVFoundation control discovery failed for '{camera.Name}', exitCode={exitCode}, output={output.Trim()}");
+                return controls;
+            }
 
-            return Task.FromResult(controls);
+            string? jsonPayload = ExtractFirstJsonObject(output);
+            if (string.IsNullOrWhiteSpace(jsonPayload))
+            {
+                logger.Warn($"AVFoundation control discovery returned no JSON payload for '{camera.Name}'. Raw output: {output.Trim()}");
+                return controls;
+            }
+
+            AvFoundationControlsResponse? response;
+            try
+            {
+                response = JsonSerializer.Deserialize<AvFoundationControlsResponse>(jsonPayload, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.Warn(ex, $"Failed to parse AVFoundation controls for '{camera.Name}': {output}");
+                return controls;
+            }
+
+            if (response?.Controls is null || response.Controls.Count == 0)
+            {
+                logger.Info($"AVFoundation reported no adjustable controls for '{camera.Name}'");
+                return controls;
+            }
+
+            foreach (AvFoundationControlDto dto in response.Controls)
+            {
+                if (!Enum.TryParse(dto.Name, out ControlType controlType))
+                {
+                    logger.Debug($"Skipping unknown AVFoundation control '{dto.Name}' for '{camera.Name}'");
+                    continue;
+                }
+
+                var control = new CameraControl(controlType, camera);
+                control.Min = dto.Min;
+                control.Max = dto.Max;
+                control.Step = dto.Step;
+                control.Default = dto.Default;
+                control.AutoSupported = dto.AutoSupported;
+                control.Flags = "rw";
+                control.ValueType = ControlValueType.Int;
+                control.Value = dto.Current;
+                control.IsAuto = dto.IsAuto;
+                control.IsModeOnly = dto.Min == dto.Max;
+                controls.Add(control);
+                logger.Info($"AVFoundation control '{dto.Name}' min={dto.Min} max={dto.Max} step={dto.Step} default={dto.Default} value={dto.Current} auto={dto.AutoSupported} modeOnly={control.IsModeOnly} for '{camera.Name}'");
+            }
+
+            logger.Info($"Discovered {controls.Count} AVFoundation settings for '{camera.Name}'");
+
+            return controls;
         }
 
         public List<string> GetCommandLineParameters(Camera camera, ICommandBuilder? builder)
@@ -276,14 +291,243 @@ namespace CollimationCircles.Services
 
         public void SetControl(Camera camera, ControlType controlType, double value)
         {
-            // Note: Camera controls via standard macOS CLI are not supported.
-            // On macOS, UVC camera control would require integration with:
-            // - AVFoundation (Apple's native framework)
-            // - libuvc (third-party library)
-            // - IOKit (low-level device control)
-            // For now, this is a UI placeholder. Actual control requires native integration.
-            
-            logger.Warn($"SetControl called for {controlType}={value} on macOS camera '{camera.Name}', but CLI control is not implemented.");
+            if (!OperatingSystem.IsMacOS() || camera.APIType is not APIType.QTCapture)
+            {
+                return;
+            }
+
+            logger.Info($"AVFoundation setting update requested: camera='{camera.Name}', control={controlType}, value={value}");
+
+            string mappedName = controlType switch
+            {
+                ControlType.ExposureTime => "ExposureTime",
+                ControlType.FocusAbsolute => "FocusAbsolute",
+                ControlType.WhiteBalance => "WhiteBalance",
+                _ => string.Empty
+            };
+
+            if (string.IsNullOrEmpty(mappedName))
+            {
+                logger.Debug($"Ignoring unsupported AVFoundation control set for {controlType} on '{camera.Name}'");
+                return;
+            }
+
+            logger.Info($"Ignored numeric AVFoundation setting update (mode-only control): camera='{camera.Name}', control={controlType}, value={value}, mappedName={mappedName}");
+        }
+
+        public void SetControlAuto(Camera camera, ControlType controlType, bool isAuto)
+        {
+            if (!OperatingSystem.IsMacOS() || camera.APIType is not APIType.QTCapture)
+            {
+                return;
+            }
+
+            logger.Info($"AVFoundation auto-setting update requested: camera='{camera.Name}', control={controlType}, isAuto={isAuto}");
+
+            string mappedName = controlType switch
+            {
+                ControlType.ExposureTime => "ExposureTime",
+                ControlType.FocusAbsolute => "FocusAbsolute",
+                ControlType.WhiteBalance => "WhiteBalance",
+                _ => string.Empty
+            };
+
+            if (string.IsNullOrEmpty(mappedName))
+            {
+                logger.Debug($"Ignoring unsupported AVFoundation auto-control set for {controlType} on '{camera.Name}'");
+                return;
+            }
+
+            string script = @"
+import Foundation
+import AVFoundation
+
+let deviceId = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : """"
+let cameraName = CommandLine.arguments.count > 2 ? CommandLine.arguments[2] : """"
+let control = CommandLine.arguments.count > 3 ? CommandLine.arguments[3] : """"
+let autoEnabled = CommandLine.arguments.count > 4 ? (CommandLine.arguments[4] == ""1"") : false
+
+let devices = AVCaptureDevice.devices(for: .video)
+guard let device = devices.first(where: { $0.uniqueID == deviceId })
+    ?? devices.first(where: { $0.localizedName == cameraName }) else {
+    print(""device-not-found"")
+    Foundation.exit(2)
+}
+
+do {
+    try device.lockForConfiguration()
+    defer { device.unlockForConfiguration() }
+
+    switch control {
+    case ""ExposureTime"":
+        if autoEnabled {
+            guard device.isExposureModeSupported(.continuousAutoExposure) else {
+                print(""unsupported"")
+                Foundation.exit(3)
+            }
+            device.exposureMode = .continuousAutoExposure
+        } else {
+            guard device.isExposureModeSupported(.locked) else {
+                print(""unsupported"")
+                Foundation.exit(3)
+            }
+            device.exposureMode = .locked
+        }
+
+    case ""FocusAbsolute"":
+        if autoEnabled {
+            guard device.isFocusModeSupported(.continuousAutoFocus) else {
+                print(""unsupported"")
+                Foundation.exit(3)
+            }
+            device.focusMode = .continuousAutoFocus
+        } else {
+            guard device.isFocusModeSupported(.locked) else {
+                print(""unsupported"")
+                Foundation.exit(3)
+            }
+            device.focusMode = .locked
+        }
+
+    case ""WhiteBalance"":
+        if autoEnabled {
+            guard device.isWhiteBalanceModeSupported(.continuousAutoWhiteBalance) else {
+                print(""unsupported"")
+                Foundation.exit(3)
+            }
+            device.whiteBalanceMode = .continuousAutoWhiteBalance
+        } else {
+            guard device.isWhiteBalanceModeSupported(.locked) else {
+                print(""unsupported"")
+                Foundation.exit(3)
+            }
+            device.whiteBalanceMode = .locked
+        }
+
+    default:
+        print(""unsupported"")
+        Foundation.exit(3)
+    }
+
+    print(""ok"")
+} catch {
+    print(""lock-failed: \(error)"")
+    Foundation.exit(4)
+}
+";
+
+            try
+            {
+                List<string> swiftArgs =
+                [
+                    camera.Path ?? string.Empty,
+                    camera.Name ?? string.Empty,
+                    mappedName,
+                    isAuto ? "1" : "0"
+                ];
+
+                (int exitCode, string output) = RunSwiftScriptAsync(script, swiftArgs).ConfigureAwait(false).GetAwaiter().GetResult();
+                if (exitCode == 0)
+                {
+                    logger.Info($"macOS AVFoundation auto-control set completed: camera='{camera.Name}', control={controlType}, isAuto={isAuto}");
+                }
+                else
+                {
+                    logger.Warn($"Failed AVFoundation auto-control set for '{camera.Name}', control={controlType}, isAuto={isAuto}, exitCode={exitCode}, output={output.Trim()}");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, $"Error setting AVFoundation auto control {controlType} on '{camera.Name}'");
+            }
+        }
+
+        private static string? ExtractFirstJsonObject(string output)
+        {
+            if (string.IsNullOrWhiteSpace(output))
+            {
+                return null;
+            }
+
+            int start = output.IndexOf('{');
+            if (start < 0)
+            {
+                return null;
+            }
+
+            int depth = 0;
+            bool inString = false;
+            bool escaped = false;
+
+            for (int i = start; i < output.Length; i++)
+            {
+                char c = output[i];
+
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (c == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (c == '"')
+                {
+                    inString = !inString;
+                    continue;
+                }
+
+                if (inString)
+                {
+                    continue;
+                }
+
+                if (c == '{')
+                {
+                    depth++;
+                }
+                else if (c == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return output[start..(i + 1)];
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static async Task<(int ExitCode, string Output)> RunSwiftScriptAsync(string script, List<string> args)
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), $"cc-avf-{Guid.NewGuid():N}.swift");
+
+            try
+            {
+                await File.WriteAllTextAsync(tempFile, script).ConfigureAwait(false);
+                List<string> swiftArgs = [tempFile];
+                swiftArgs.AddRange(args);
+                return await AppService.StartProcessAsync("/usr/bin/swift", swiftArgs).ConfigureAwait(false);
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(tempFile))
+                    {
+                        File.Delete(tempFile);
+                    }
+                }
+                catch
+                {
+                    // Best effort cleanup only.
+                }
+            }
         }
     }
 }

--- a/CollimationCircles/StartupOptions.cs
+++ b/CollimationCircles/StartupOptions.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace CollimationCircles
+{
+    internal static class StartupOptions
+    {
+        public static string? AutoConnectCameraName { get; private set; }
+
+        public static void Initialize(string[] args)
+        {
+            AutoConnectCameraName = null;
+
+            if (args is null || args.Length == 0)
+            {
+                return;
+            }
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                string arg = args[i];
+
+                if (string.Equals(arg, "--camera", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (i + 1 < args.Length && !string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        AutoConnectCameraName = args[i + 1].Trim();
+                    }
+
+                    continue;
+                }
+
+                const string cameraPrefix = "--camera=";
+                if (arg.StartsWith(cameraPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    string value = arg[cameraPrefix.Length..].Trim();
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        AutoConnectCameraName = value;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/CollimationCircles/ViewModels/CameraControlsViewModel.cs
+++ b/CollimationCircles/ViewModels/CameraControlsViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using LibVLCSharp.Shared;
+using System.ComponentModel;
 
 namespace CollimationCircles.ViewModels
 {
@@ -16,7 +17,7 @@ namespace CollimationCircles.ViewModels
         private readonly StreamViewModel streamViewModel;
 
         [ObservableProperty]
-        private Camera camera;
+        private Camera camera = new();
 
         [ObservableProperty]
         private bool isLibCamera;
@@ -24,28 +25,42 @@ namespace CollimationCircles.ViewModels
         [ObservableProperty]
         private bool isPlaying;
 
+        [ObservableProperty]
+        private bool hasCameraControls;
+
         public CameraControlsViewModel()
         {
             this.libVLCService = Ioc.Default.GetRequiredService<ILibVLCService>();
             this.streamViewModel = Ioc.Default.GetRequiredService<StreamViewModel>();
 
+            RefreshCameraContext();
 
-            Camera = streamViewModel.SelectedCamera;
-            IsLibCamera = Camera.APIType == APIType.LibCamera;
+            this.streamViewModel.PropertyChanged += StreamViewModel_PropertyChanged;
 
             WeakReferenceMessenger.Default.Register<CameraStateMessage>(this, (r, m) =>
             {
-                Camera = streamViewModel.SelectedCamera;
-                IsLibCamera = Camera.APIType == APIType.LibCamera;
-
-                // Drive IsPlaying from the camera state message. The MediaPlayer is
-                // lazily initialised (null at construction time), so subscribing to its
-                // events directly in the constructor never works. The messenger is the
-                // same source StreamViewModel uses to track play state.
                 IsPlaying = m.Value == CameraState.Playing;
+                RefreshCameraContext();
             });
 
             Title = $"{ResSvc.TryGetString("CollimationCircles")} - {ResSvc.TryGetString("CameraControls")}";
+        }
+
+        private void StreamViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(StreamViewModel.SelectedCamera) ||
+                e.PropertyName == nameof(StreamViewModel.IsPlaying))
+            {
+                RefreshCameraContext();
+            }
+        }
+
+        private void RefreshCameraContext()
+        {
+            Camera = streamViewModel.SelectedCamera;
+            IsLibCamera = Camera.APIType == APIType.LibCamera;
+            IsPlaying = streamViewModel.IsPlaying;
+            HasCameraControls = Camera.Controls is not null && Camera.Controls.Count > 0;
         }
 
         [RelayCommand]

--- a/CollimationCircles/ViewModels/StreamViewModel.cs
+++ b/CollimationCircles/ViewModels/StreamViewModel.cs
@@ -80,6 +80,23 @@ namespace CollimationCircles.ViewModels
             {
                 CameraList = [.. await cameraControlService.GetCameraList()];
                 SelectedCamera = CameraList?.Where(c => c.Name == settingsViewModel.LastSelectedCamera)?.FirstOrDefault() ?? CameraList?.FirstOrDefault() ?? new();
+
+                if (!string.IsNullOrWhiteSpace(StartupOptions.AutoConnectCameraName) && CameraList.Count > 0)
+                {
+                    string targetCameraName = StartupOptions.AutoConnectCameraName!;
+                    Camera? cliCamera = CameraList.FirstOrDefault(c => string.Equals(c.Name, targetCameraName, StringComparison.OrdinalIgnoreCase));
+
+                    if (cliCamera is not null)
+                    {
+                        SelectedCamera = cliCamera;
+                        logger.Info($"Startup option --camera matched '{SelectedCamera.Name}'. Starting stream automatically.");
+                        await StartSelectedCameraAsync();
+                    }
+                    else
+                    {
+                        logger.Warn($"Startup option --camera='{targetCameraName}' did not match any discovered camera.");
+                    }
+                }
             });
 
             WeakReferenceMessenger.Default.Register<CameraStateMessage>(this, (r, m) =>
@@ -133,7 +150,12 @@ namespace CollimationCircles.ViewModels
         }
 
         [RelayCommand(CanExecute = nameof(CanExecutePlayPause))]
-        private void PlayPause()
+        private async Task PlayPause()
+        {
+            await StartSelectedCameraAsync();
+        }
+
+        private async Task StartSelectedCameraAsync()
         {
             Guard.IsNotNull(SelectedCamera);
 
@@ -149,7 +171,7 @@ namespace CollimationCircles.ViewModels
                 }
                 else
                 {
-                    libVLCService.Play(SelectedCamera, DisplayAdvancedDShowDialog);
+                    await libVLCService.Play(SelectedCamera, DisplayAdvancedDShowDialog);
                 }
 
                 return;
@@ -162,7 +184,7 @@ namespace CollimationCircles.ViewModels
             {
                 if (!libVLCService.MediaPlayer.IsPlaying)
                 {
-                    libVLCService.Play(SelectedCamera, DisplayAdvancedDShowDialog);
+                    await libVLCService.Play(SelectedCamera, DisplayAdvancedDShowDialog);
                 }
                 else
                 {
@@ -175,7 +197,7 @@ namespace CollimationCircles.ViewModels
             // First attempt: try to start the stream (this triggers lazy init).
             if (!libVLCService.IsAvailable)
             {
-                libVLCService.Play(SelectedCamera, DisplayAdvancedDShowDialog);
+                await libVLCService.Play(SelectedCamera, DisplayAdvancedDShowDialog);
             }
 
             if (!libVLCService.IsAvailable)


### PR DESCRIPTION
Restore AVFoundation control discovery/logging and clarify mode-only controls.

With LibVLC + avcapture + AVFoundation on macOS in this project, what is reliably available is mostly mode controls (Auto and Locked) such as exposure mode and focus mode for cameras that expose them. AVFoundation does not expose gain, exposure time, etc.

In the future, the idea would be to not use avcapture and AVFoundation and go directly for example with libuvc (wor in progress in PR https://github.com/sajmons/CollimationCircles/pull/66 - see issue https://github.com/sajmons/CollimationCircles/issues/61). **But this change is bigger.**

**For for now** 

This PR removed the placeholders that were put and show the controls available from AVFoundation on macOS.

**Example:**

<img width="263" height="291" alt="image" src="https://github.com/user-attachments/assets/f3471a9b-62c9-442e-8683-e35c1ed425d0" />

-----

Changes:
- Reworked macOS QTCapture settings discovery using an AVFoundation Swift bridge.
- Restored and expanded logs for settings discovery and setting updates.
- Fixed parsing by extracting JSON from mixed Swift output (JSON plus warning text).
- Routed QTCapture auto-setting updates through CameraControlService.
- Integrated startup camera flow via StartupOptions, Program, and StreamViewModel.
- Improved camera controls UI sync and added explicit no-controls feedback.
- Added IsModeOnly handling so mode-only controls show Auto or Locked toggles without misleading numeric sliders.

Limitations:
- On current macOS AVFoundation plus avcapture path, exposed controls are mostly mode toggles (Auto or Locked), not true numeric gain or exposure ranges.
- Numeric updates for mode-only controls are intentionally ignored.
- Some cameras (FaceTime, OBS Virtual Camera, Continuity Camera) expose no adjustable controls through this API path.
- AVCaptureDevice.devices(for:) emits deprecation warnings in Swift output (functional but noisy).