### PR TITLE
fix: restore camera controls visibility while streaming

### DIFF
--- a/CollimationCircles/Controls/DynamicCameraControlsUserControl.axaml
+++ b/CollimationCircles/Controls/DynamicCameraControlsUserControl.axaml
@@ -26,7 +26,8 @@
   </UserControl.Styles>
   <StackPanel
     Orientation="Vertical"
-    Spacing="20">
+    Spacing="20"
+    IsVisible="{Binding IsPlaying}">
     <TextBlock
       IsVisible="{Binding !HasCameraControls}"
       Text="No adjustable camera settings are exposed for this camera on macOS AVFoundation."


### PR DESCRIPTION
Restore the original behavior lost in fc10c0f so the camera controls panel is only visible when streaming is active.

This keeps the newer macOS AVFoundation discovery and mode-only UI changes, but reintroduces the IsPlaying visibility gate on the root controls panel.