### PR TITLE
refactor: move ZWO and UVC files into Services/Zwo/ and Services/Uvc/subdirectories

### DIFF
--- a/CollimationCircles/App.axaml.cs
+++ b/CollimationCircles/App.axaml.cs
@@ -3,6 +3,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using CollimationCircles.Services;
+using CollimationCircles.Services.Uvc;
+using CollimationCircles.Services.Zwo;
 using CollimationCircles.ViewModels;
 using CollimationCircles.Views;
 using CommunityToolkit.Mvvm.DependencyInjection;

--- a/CollimationCircles/Program.cs
+++ b/CollimationCircles/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using CollimationCircles.Services;
+using CollimationCircles.Services.Uvc;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/CollimationCircles/Services/CameraControlService.cs
+++ b/CollimationCircles/Services/CameraControlService.cs
@@ -1,4 +1,5 @@
 ﻿using CollimationCircles.Models;
+using CollimationCircles.Services.Zwo;
 using CommunityToolkit.Diagnostics;
 using System;
 using System.Collections.Generic;

--- a/CollimationCircles/Services/LibVLCService.cs
+++ b/CollimationCircles/Services/LibVLCService.cs
@@ -1,6 +1,8 @@
 using CollimationCircles.Helper.RpiCameraTools;
 using CollimationCircles.Messages;
 using CollimationCircles.Models;
+using CollimationCircles.Services.Uvc;
+using CollimationCircles.Services.Zwo;
 using Avalonia.Threading;
 using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.DependencyInjection;

--- a/CollimationCircles/Services/MacOSCameraDetect.cs
+++ b/CollimationCircles/Services/MacOSCameraDetect.cs
@@ -1,4 +1,5 @@
 using CollimationCircles.Models;
+using CollimationCircles.Services.Uvc;
 using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using System;

--- a/CollimationCircles/Services/Uvc/IUvcFrameSource.cs
+++ b/CollimationCircles/Services/Uvc/IUvcFrameSource.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace CollimationCircles.Services
+namespace CollimationCircles.Services.Uvc
 {
     /// <summary>
     /// Provides direct frame delivery from a UVC camera via libusb, bypassing LibVLC.

--- a/CollimationCircles/Services/Uvc/IokitHelper.cs
+++ b/CollimationCircles/Services/Uvc/IokitHelper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace CollimationCircles.Services
+namespace CollimationCircles.Services.Uvc
 {
     /// <summary>
     /// Minimal IOKit P/Invoke helper for detaching the macOS kernel UVC driver.

--- a/CollimationCircles/Services/Uvc/LibUvcInterop.cs
+++ b/CollimationCircles/Services/Uvc/LibUvcInterop.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace CollimationCircles.Services
+namespace CollimationCircles.Services.Uvc
 {
     /// <summary>
     /// P/Invoke bindings for libuvc (https://github.com/libuvc/libuvc).

--- a/CollimationCircles/Services/Uvc/UvcFrameSource.cs
+++ b/CollimationCircles/Services/Uvc/UvcFrameSource.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
-namespace CollimationCircles.Services
+namespace CollimationCircles.Services.Uvc
 {
     /// <summary>
     /// Direct UVC camera frame source using the libuvc library

--- a/CollimationCircles/Services/Zwo/IZwoFrameSource.cs
+++ b/CollimationCircles/Services/Zwo/IZwoFrameSource.cs
@@ -2,7 +2,7 @@ using CollimationCircles.Models;
 using System;
 using System.Threading.Tasks;
 
-namespace CollimationCircles.Services
+namespace CollimationCircles.Services.Zwo
 {
     /// <summary>
     /// Provides direct frame delivery from a ZWO ASI camera, bypassing LibVLC.

--- a/CollimationCircles/Services/Zwo/ZWOASICameraInterop.cs
+++ b/CollimationCircles/Services/Zwo/ZWOASICameraInterop.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace CollimationCircles.Services
+namespace CollimationCircles.Services.Zwo
 {
     /// <summary>
     /// P/Invoke wrapper for ZWO ASI Camera SDK (libASICamera2)

--- a/CollimationCircles/Services/Zwo/ZWOCameraDetect.cs
+++ b/CollimationCircles/Services/Zwo/ZWOCameraDetect.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace CollimationCircles.Services
+namespace CollimationCircles.Services.Zwo
 {
     /// <summary>
     /// Detects and manages ZWO ASI cameras using the native SDK

--- a/CollimationCircles/Services/Zwo/ZWOLiveStreamService.cs
+++ b/CollimationCircles/Services/Zwo/ZWOLiveStreamService.cs
@@ -12,7 +12,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace CollimationCircles.Services
+namespace CollimationCircles.Services.Zwo
 {
     /// <summary>
     /// Captures frames from a ZWO ASI camera using the ASI SDK and serves them

--- a/CollimationCircles/Services/Zwo/ZwoFrameSource.cs
+++ b/CollimationCircles/Services/Zwo/ZwoFrameSource.cs
@@ -2,7 +2,7 @@ using CollimationCircles.Models;
 using System;
 using System.Threading.Tasks;
 
-namespace CollimationCircles.Services
+namespace CollimationCircles.Services.Zwo
 {
     /// <summary>
     /// Adapter that wraps <see cref="ZWOLiveStreamService"/> in direct-rendering

--- a/CollimationCircles/ViewModels/StreamViewModel.cs
+++ b/CollimationCircles/ViewModels/StreamViewModel.cs
@@ -2,6 +2,8 @@ using Avalonia.Threading;
 using CollimationCircles.Messages;
 using CollimationCircles.Models;
 using CollimationCircles.Services;
+using CollimationCircles.Services.Uvc;
+using CollimationCircles.Services.Zwo;
 using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;

--- a/CollimationCircles/Views/StreamView.axaml.cs
+++ b/CollimationCircles/Views/StreamView.axaml.cs
@@ -2,6 +2,8 @@ using Avalonia;
 using Avalonia.Controls;
 using CollimationCircles.Messages;
 using CollimationCircles.Services;
+using CollimationCircles.Services.Uvc;
+using CollimationCircles.Services.Zwo;
 using CollimationCircles.ViewModels;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Messaging;


### PR DESCRIPTION
- Move ZWO-related files (ZWOASICameraInterop, ZWOCameraDetect, ZwoFrameSource, ZWOLiveStreamService, IZwoFrameSource) to Services/Zwo/
- Move UVC-related files (UvcFrameSource, IUvcFrameSource, LibUvcInterop, IokitHelper) to Services/Uvc/
- Update namespaces from CollimationCircles.Services to CollimationCircles.Services.Zwo and CollimationCircles.Services.Uvc
- Add using directives in all referencing files